### PR TITLE
ci(gallery): stop writing GHA layer cache on PR builds

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -77,5 +77,8 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
             ${{ steps.meta.outputs.image }}:latest
+          # Read layer cache always (free, speeds builds), but only WRITE it on real
+          # releases. PR validation builds with mode=max used to balloon the GHA cache
+          # (10 GB/repo cap) with throwaway per-PR layer blobs, so PRs no longer push cache.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ steps.meta.outputs.push == 'true' && 'type=gha,mode=max' || '' }}


### PR DESCRIPTION
PR validation builds publish nothing but cached every intermediate layer (`cache-to mode=max`), flooding the 10 GB/repo GHA cache with throwaway per-PR buildkit blobs (was ~7.9 GB across 439 caches). Now `cache-to` runs only on real releases (`push==true`); PR builds still `cache-from` for speed but write nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)