### PR TITLE
Add focused per-component IDE demos to the Gallery

### DIFF
--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeBackstageDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeBackstageDemo.razor
@@ -1,0 +1,72 @@
+@using Flare.Components.IDE
+
+@* FlareBackstage / FlareBackstageItem: the Office "File" menu - a full-surface overlay with a left
+   navigation rail and a content area. Open it with the File button; pick a rail entry to switch the
+   content; the back arrow raises OpenChanged(false). The overlay fills the nearest positioned box. *@
+<div style="position:relative;height:340px;border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);overflow:hidden;background:var(--flare-color-surface);">
+    <div style="padding:0.75rem;display:flex;align-items:center;gap:0.5rem;border-bottom:1px solid var(--flare-color-outline-variant);">
+        <FlareButton Variant="ButtonVariant.Tonal" Size="ButtonSize.Sm" OnClick="@(() => _open = true)">
+            <LeadingIcon><FlareIcon Name="folder_open" /></LeadingIcon>
+            <ChildContent>File</ChildContent>
+        </FlareButton>
+        <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+            The document surface sits behind the backstage.
+        </FlareText>
+    </div>
+
+    <div style="padding:1rem;">
+        <FlareText Typo="TypographyScale.BodyMedium" Color="FlareColor.OnSurfaceVariant">
+            Document content...
+        </FlareText>
+    </div>
+
+    <FlareBackstage @bind-Open="_open">
+        <NavContent>
+            <FlareBackstageItem Icon="note_add" Label="New" Active="_selected == BackstageNav.New"
+                                OnClick="@(() => _selected = BackstageNav.New)" />
+            <FlareBackstageItem Icon="folder_open" Label="Open" Active="_selected == BackstageNav.Open"
+                                OnClick="@(() => _selected = BackstageNav.Open)" />
+            <FlareBackstageItem Icon="save" Label="Save As" Active="_selected == BackstageNav.Save"
+                                OnClick="@(() => _selected = BackstageNav.Save)" />
+            <FlareBackstageItem Icon="print" Label="Print" Active="_selected == BackstageNav.Print"
+                                OnClick="@(() => _selected = BackstageNav.Print)" />
+            <FlareBackstageItem Icon="settings" Label="Options" Active="_selected == BackstageNav.Options"
+                                OnClick="@(() => _selected = BackstageNav.Options)" />
+        </NavContent>
+        <ChildContent>
+            <FlareStack Gap="FlareSpacing.Small">
+                <FlareText Typo="TypographyScale.HeadlineSmall">@Heading</FlareText>
+                <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodyMedium">
+                    @Body
+                </FlareText>
+            </FlareStack>
+        </ChildContent>
+    </FlareBackstage>
+</div>
+
+@code {
+    private enum BackstageNav { New, Open, Save, Print, Options }
+
+    private bool _open;
+    private BackstageNav _selected = BackstageNav.New;
+
+    private string Heading => _selected switch
+    {
+        BackstageNav.New => "New",
+        BackstageNav.Open => "Open",
+        BackstageNav.Save => "Save As",
+        BackstageNav.Print => "Print",
+        BackstageNav.Options => "Options",
+        _ => "",
+    };
+
+    private string Body => _selected switch
+    {
+        BackstageNav.New => "Choose a template to start a new document.",
+        BackstageNav.Open => "Browse recent files or pick a location.",
+        BackstageNav.Save => "Pick a folder and format to save a copy.",
+        BackstageNav.Print => "Preview the layout and choose a printer.",
+        BackstageNav.Options => "Configure the editor, theme, and shortcuts.",
+        _ => "",
+    };
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeCommandBarsDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeCommandBarsDemo.razor
@@ -1,0 +1,84 @@
+@using Flare.Components.IDE
+
+@* The three classic command strips, standalone: FlareQuickAccessToolbar (Office mini strip),
+   FlareMenuBar with FlareMenu dropdowns, and a FlareToolbar icon command bar with separators and a
+   small inline field. Toggle Dense to tighten the toolbar. *@
+<FlareStack Gap="FlareSpacing.Small">
+    <FlareSwitch @bind-Value="_dense" Label="Dense toolbar" />
+
+    <div style="border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);overflow:hidden;">
+        <FlareQuickAccessToolbar>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Save" OnClick="@(() => Set("Save"))">
+                <FlareIcon Name="save" />
+            </FlareButton>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Undo" OnClick="@(() => Set("Undo"))">
+                <FlareIcon Name="undo" />
+            </FlareButton>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Redo" OnClick="@(() => Set("Redo"))">
+                <FlareIcon Name="redo" />
+            </FlareButton>
+        </FlareQuickAccessToolbar>
+
+        <FlareMenuBar>
+            <FlareMenu Anchor="MenuAnchor.BottomLeft" AriaLabel="File menu">
+                <Activator>
+                    <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Sm">File</FlareButton>
+                </Activator>
+                <ChildContent>
+                    <FlareMenuItem Icon="note_add" OnClick="@(() => Set("File > New"))">New</FlareMenuItem>
+                    <FlareMenuItem Icon="folder_open" OnClick="@(() => Set("File > Open"))">Open</FlareMenuItem>
+                    <FlareMenuItem Icon="save" OnClick="@(() => Set("File > Save"))">Save</FlareMenuItem>
+                </ChildContent>
+            </FlareMenu>
+            <FlareMenu Anchor="MenuAnchor.BottomLeft" AriaLabel="Edit menu">
+                <Activator>
+                    <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Sm">Edit</FlareButton>
+                </Activator>
+                <ChildContent>
+                    <FlareMenuItem Icon="content_cut" OnClick="@(() => Set("Edit > Cut"))">Cut</FlareMenuItem>
+                    <FlareMenuItem Icon="content_copy" OnClick="@(() => Set("Edit > Copy"))">Copy</FlareMenuItem>
+                    <FlareMenuItem Icon="content_paste" OnClick="@(() => Set("Edit > Paste"))">Paste</FlareMenuItem>
+                </ChildContent>
+            </FlareMenu>
+            <FlareMenu Anchor="MenuAnchor.BottomLeft" AriaLabel="View menu">
+                <Activator>
+                    <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Sm">View</FlareButton>
+                </Activator>
+                <ChildContent>
+                    <FlareMenuItem Icon="account_tree" OnClick="@(() => Set("View > Solution Explorer"))">Solution Explorer</FlareMenuItem>
+                    <FlareMenuItem Icon="terminal" OnClick="@(() => Set("View > Terminal"))">Terminal</FlareMenuItem>
+                </ChildContent>
+            </FlareMenu>
+        </FlareMenuBar>
+
+        <FlareToolbar Dense="_dense">
+            <FlareButton Variant="ButtonVariant.Filled" Size="ButtonSize.Xs" OnClick="@(() => Set("Start"))">
+                <LeadingIcon><FlareIcon Name="play_arrow" /></LeadingIcon>
+                <ChildContent>Start</ChildContent>
+            </FlareButton>
+            <FlareRibbonSeparator />
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Build" OnClick="@(() => Set("Build"))">
+                <FlareIcon Name="build" />
+            </FlareButton>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Debug" OnClick="@(() => Set("Debug"))">
+                <FlareIcon Name="bug_report" />
+            </FlareButton>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Stop" OnClick="@(() => Set("Stop"))">
+                <FlareIcon Name="stop" />
+            </FlareButton>
+            <FlareRibbonSeparator />
+            <FlareField TValue="string" Size="FieldSize.Sm" Placeholder="Search (Ctrl+,)" Style="width:180px;" />
+        </FlareToolbar>
+    </div>
+
+    <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+        Last command: <strong>@_status</strong>
+    </FlareText>
+</FlareStack>
+
+@code {
+    private bool _dense = true;
+    private string _status = "(none)";
+
+    private void Set(string action) => _status = action;
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeDocumentTabsDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeDocumentTabsDemo.razor
@@ -1,0 +1,82 @@
+@using Flare.Components.IDE
+
+@* Editor-style document tabs driven by a model list: per-tab Icon, a Modified indicator, a
+   non-closeable (pinned) tab, plus add and close handling. OnTabChanged / OnTabClose report back so
+   the host owns the open-document list. *@
+<FlareStack Gap="FlareSpacing.Small">
+    <FlareStack Row Gap="FlareSpacing.Small" Align="FlareAlignItems.Center">
+        <FlareButton Variant="ButtonVariant.Tonal" Size="ButtonSize.Sm" OnClick="AddDocument">
+            <LeadingIcon><FlareIcon Name="add" /></LeadingIcon>
+            <ChildContent>New file</ChildContent>
+        </FlareButton>
+        <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+            Active: <strong>@(_active ?? "(none)")</strong>
+        </FlareText>
+    </FlareStack>
+
+    <div style="height:240px;border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);overflow:hidden;">
+        <FlareDocumentTabs OnTabChanged="OnChanged" OnTabClose="OnClose">
+            @foreach (var doc in _docs)
+            {
+                <FlareDocumentTab @key="doc.Id" Title="@doc.Title" Icon="@doc.Icon"
+                                  Modified="doc.Modified" Closeable="doc.Closeable">
+                    <div style="padding:0.75rem;display:flex;flex-direction:column;gap:0.35rem;">
+                        <FlareText Typo="TypographyScale.TitleSmall">@doc.Title</FlareText>
+                        <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+                            @doc.Description
+                        </FlareText>
+                        @if (doc.Modified)
+                        {
+                            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" OnClick="@(() => Save(doc))">
+                                <LeadingIcon><FlareIcon Name="save" /></LeadingIcon>
+                                <ChildContent>Save (clear modified)</ChildContent>
+                            </FlareButton>
+                        }
+                    </div>
+                </FlareDocumentTab>
+            }
+        </FlareDocumentTabs>
+    </div>
+
+    <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+        The pinned <code>App.razor</code> tab has <code>Closeable="false"</code> so it has no close button.
+    </FlareText>
+</FlareStack>
+
+@code {
+    private sealed class Doc
+    {
+        public required int Id { get; init; }
+        public required string Title { get; init; }
+        public required string Icon { get; init; }
+        public required string Description { get; init; }
+        public bool Modified { get; set; }
+        public bool Closeable { get; set; } = true;
+    }
+
+    private int _nextId = 4;
+    private string? _active;
+
+    private readonly List<Doc> _docs =
+    [
+        new() { Id = 1, Title = "Program.cs", Icon = "description", Description = "Application entry point.", Modified = true },
+        new() { Id = 2, Title = "README.md", Icon = "article", Description = "Project overview and docs." },
+        new() { Id = 3, Title = "App.razor", Icon = "code", Description = "Root component (pinned).", Closeable = false },
+    ];
+
+    private void OnChanged(string title) => _active = title;
+
+    private void OnClose(string title)
+    {
+        var doc = _docs.FirstOrDefault(d => d.Title == title);
+        if (doc is not null) _docs.Remove(doc);
+    }
+
+    private void AddDocument()
+    {
+        var id = _nextId++;
+        _docs.Add(new Doc { Id = id, Title = $"Untitled-{id}.cs", Icon = "draft", Description = "A new, unsaved file.", Modified = true });
+    }
+
+    private void Save(Doc doc) => doc.Modified = false;
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeFormulaBarDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeFormulaBarDemo.razor
@@ -1,0 +1,86 @@
+@using Flare.Components.IDE
+
+@* FlareFormulaBar: the Excel name box + fx marker + formula editor, built on FlareField. Both the
+   name box (CellRef) and the editor (Value) are two-way bound. Click a cell to select it - the bar
+   loads that cell; edit the formula and it writes back to the selected cell. *@
+<FlareStack Gap="FlareSpacing.Small">
+    <div style="border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);overflow:hidden;">
+        <FlareFormulaBar CellRef="_cellRef" CellRefChanged="OnCellRefChanged"
+                         Value="_formula" ValueChanged="OnFormulaChanged"
+                         Placeholder="Enter a value or =formula" />
+        <table style="border-collapse:collapse;width:100%;font-size:0.85rem;">
+            <thead>
+                <tr>
+                    <th style="@_headStyle;width:2rem;"></th>
+                    @foreach (var col in _cols)
+                    {
+                        <th style="@_headStyle">@col</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in _rows)
+                {
+                    <tr>
+                        <th style="@_headStyle">@row</th>
+                        @foreach (var col in _cols)
+                        {
+                            var cell = $"{col}{row}";
+                            var selected = cell == _cellRef;
+                            <td style="@CellStyle(selected)" @onclick="@(() => Select(cell))">
+                                @_cells.GetValueOrDefault(cell, "")
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+
+    <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+        Selected cell: <strong>@_cellRef</strong>
+    </FlareText>
+</FlareStack>
+
+@code {
+    private readonly string[] _cols = ["A", "B", "C"];
+    private readonly int[] _rows = [1, 2, 3];
+
+    private string? _cellRef = "A1";
+    private string? _formula = "Revenue";
+
+    private readonly Dictionary<string, string> _cells = new()
+    {
+        ["A1"] = "Revenue", ["B1"] = "Cost", ["C1"] = "Profit",
+        ["A2"] = "1200", ["B2"] = "800", ["C2"] = "=A2-B2",
+    };
+
+    private void Select(string cell)
+    {
+        _cellRef = cell;
+        _formula = _cells.GetValueOrDefault(cell, "");
+    }
+
+    private void OnCellRefChanged(string? value)
+    {
+        _cellRef = value;
+        _formula = _cells.GetValueOrDefault(value ?? "", "");
+    }
+
+    private void OnFormulaChanged(string? value)
+    {
+        _formula = value;
+        if (!string.IsNullOrEmpty(_cellRef))
+            _cells[_cellRef] = value ?? "";
+    }
+
+    private const string _headStyle =
+        "background:var(--flare-color-surface-container);color:var(--flare-color-on-surface-variant);" +
+        "border:1px solid var(--flare-color-outline-variant);padding:0.25rem 0.5rem;text-align:center;font-weight:500;";
+
+    private static string CellStyle(bool selected) =>
+        "border:1px solid var(--flare-color-outline-variant);padding:0.25rem 0.5rem;cursor:pointer;" +
+        (selected
+            ? "outline:2px solid var(--flare-color-primary);outline-offset:-2px;background:var(--flare-color-primary-container);"
+            : "");
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdePropertyGridDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdePropertyGridDemo.razor
@@ -1,0 +1,54 @@
+@using Flare.Components.IDE
+
+@* FlarePropertyGrid / FlarePropertyGridItem: a name/value property sheet whose values are plain text
+   or any editor. Here each row hosts a real Flare input (field, select, checkbox, switch, numeric)
+   bound to a model, and the property sheet drives the live FlareButton preview on the right. *@
+<div style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-start;">
+    <FlarePropertyGrid Title="button1 (FlareButton)"
+                       Style="width:320px;border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);">
+        <FlarePropertyGridItem Name="(Name)" Value="button1" />
+        <FlarePropertyGridItem Name="Text">
+            <FlareField TValue="string" Size="FieldSize.Sm" @bind-Value="_text" />
+        </FlarePropertyGridItem>
+        <FlarePropertyGridItem Name="Variant">
+            <FlareSelect TValue="ButtonVariant" Size="FieldSize.Sm"
+                         Items="_variants" @bind-Value="_variant" />
+        </FlarePropertyGridItem>
+        <FlarePropertyGridItem Name="Width">
+            <FlareNumericField TValue="int" Size="FieldSize.Sm" Suffix="px" Min="72" Max="320" Step="8"
+                               @bind-Value="_width" />
+        </FlarePropertyGridItem>
+        <FlarePropertyGridItem Name="Disabled">
+            <FlareCheckbox @bind-Value="_disabled" />
+        </FlarePropertyGridItem>
+        <FlarePropertyGridItem Name="Visible">
+            <FlareSwitch @bind-Value="_visible" />
+        </FlarePropertyGridItem>
+    </FlarePropertyGrid>
+
+    <FlarePaper Elevation="0"
+                Style="flex:1;min-width:220px;min-height:180px;display:flex;align-items:center;justify-content:center;border:1px dashed var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);">
+        @if (_visible)
+        {
+            <FlareButton Variant="_variant" Disabled="@(_disabled == true)" Style="@($"width:{_width}px;")">
+                @(_text ?? "")
+            </FlareButton>
+        }
+        else
+        {
+            <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodySmall">
+                Visible = false
+            </FlareText>
+        }
+    </FlarePaper>
+</div>
+
+@code {
+    private string? _text = "Click me";
+    private ButtonVariant _variant = ButtonVariant.Filled;
+    private int _width = 160;
+    private bool? _disabled = false;
+    private bool _visible = true;
+
+    private readonly ButtonVariant[] _variants = Enum.GetValues<ButtonVariant>();
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeRibbonDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeRibbonDemo.razor
@@ -1,0 +1,86 @@
+@using Flare.Components.IDE
+
+@* Standalone FlareRibbon: tabbed command groups with large (icon + label) and small (icon-only)
+   buttons, an in-group separator, and a dropdown gallery. Toggle SizeMode to collapse the whole
+   ribbon to its tab strip. Built only from Flare + Flare.Components.IDE. *@
+<FlareStack Gap="FlareSpacing.Small">
+    <FlareSwitch Value="_collapsed" ValueChanged="OnCollapsedChanged"
+                 Label="Collapse to tabs only (SizeMode)" />
+
+    <div style="border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);overflow:hidden;">
+        <FlareRibbon SizeMode="@(_collapsed ? RibbonSizeMode.Collapsed : RibbonSizeMode.Full)"
+                     OnTabChanged="OnTab">
+            <FlareRibbonTab Title="Home">
+                <FlareRibbonGroup Label="Clipboard">
+                    <FlareRibbonButton Icon="content_paste" Label="Paste" Tooltip="Paste" IsLarge="true"
+                                       OnClick="@(() => Set("Paste"))" />
+                    <FlareRibbonButton Icon="content_cut" Tooltip="Cut" OnClick="@(() => Set("Cut"))" />
+                    <FlareRibbonButton Icon="content_copy" Tooltip="Copy" OnClick="@(() => Set("Copy"))" />
+                </FlareRibbonGroup>
+                <FlareRibbonGroup Label="Font">
+                    <FlareRibbonButton Icon="format_bold" Tooltip="Bold" OnClick="@(() => Set("Bold"))" />
+                    <FlareRibbonButton Icon="format_italic" Tooltip="Italic" OnClick="@(() => Set("Italic"))" />
+                    <FlareRibbonButton Icon="format_underlined" Tooltip="Underline" OnClick="@(() => Set("Underline"))" />
+                    <FlareRibbonSeparator />
+                    <FlareRibbonDropdown Icon="format_color_text" Tooltip="Font color">
+                        <MenuContent>
+                            <FlareMenuItem Icon="circle" OnClick="@(() => Set("Color: Red"))">Red</FlareMenuItem>
+                            <FlareMenuItem Icon="circle" OnClick="@(() => Set("Color: Green"))">Green</FlareMenuItem>
+                            <FlareMenuItem Icon="circle" OnClick="@(() => Set("Color: Blue"))">Blue</FlareMenuItem>
+                        </MenuContent>
+                    </FlareRibbonDropdown>
+                </FlareRibbonGroup>
+                <FlareRibbonGroup Label="Styles">
+                    <FlareRibbonDropdown Icon="palette" Label="Cell Styles" Tooltip="Cell styles" IsLarge="true">
+                        <MenuContent>
+                            <FlareMenuItem OnClick="@(() => Set("Style: Normal"))">Normal</FlareMenuItem>
+                            <FlareMenuItem OnClick="@(() => Set("Style: Heading 1"))">Heading 1</FlareMenuItem>
+                            <FlareMenuItem OnClick="@(() => Set("Style: Currency"))">Currency</FlareMenuItem>
+                        </MenuContent>
+                    </FlareRibbonDropdown>
+                </FlareRibbonGroup>
+            </FlareRibbonTab>
+            <FlareRibbonTab Title="Insert">
+                <FlareRibbonGroup Label="Tables">
+                    <FlareRibbonButton Icon="table" Label="Table" Tooltip="Insert table" IsLarge="true"
+                                       OnClick="@(() => Set("Insert table"))" />
+                    <FlareRibbonButton Icon="pivot_table_chart" Label="PivotTable" Tooltip="PivotTable" IsLarge="true"
+                                       OnClick="@(() => Set("Insert PivotTable"))" />
+                </FlareRibbonGroup>
+                <FlareRibbonGroup Label="Charts">
+                    <FlareRibbonButton Icon="bar_chart" Tooltip="Column chart" OnClick="@(() => Set("Column chart"))" />
+                    <FlareRibbonButton Icon="show_chart" Tooltip="Line chart" OnClick="@(() => Set("Line chart"))" />
+                    <FlareRibbonButton Icon="pie_chart" Tooltip="Pie chart" OnClick="@(() => Set("Pie chart"))" />
+                </FlareRibbonGroup>
+            </FlareRibbonTab>
+            <FlareRibbonTab Title="View">
+                <FlareRibbonGroup Label="Zoom">
+                    <FlareRibbonButton Icon="zoom_in" Label="Zoom In" Tooltip="Zoom in" IsLarge="true"
+                                       OnClick="@(() => Set("Zoom in"))" />
+                    <FlareRibbonButton Icon="zoom_out" Label="Zoom Out" Tooltip="Zoom out" IsLarge="true"
+                                       OnClick="@(() => Set("Zoom out"))" />
+                </FlareRibbonGroup>
+                <FlareRibbonGroup Label="Show">
+                    <FlareRibbonButton Icon="grid_on" Tooltip="Grid lines" OnClick="@(() => Set("Toggle grid lines"))" />
+                    <FlareRibbonButton Icon="wrap_text" Tooltip="Word wrap" OnClick="@(() => Set("Toggle word wrap"))" />
+                </FlareRibbonGroup>
+                <FlareRibbonGroup Label="Disabled">
+                    <FlareRibbonButton Icon="lock" Label="Locked" Tooltip="Disabled command" IsLarge="true" Disabled="true" />
+                </FlareRibbonGroup>
+            </FlareRibbonTab>
+        </FlareRibbon>
+    </div>
+
+    <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+        Last command: <strong>@_status</strong>
+    </FlareText>
+</FlareStack>
+
+@code {
+    private bool _collapsed;
+    private string _status = "(none)";
+
+    private void OnCollapsedChanged(bool value) => _collapsed = value;
+    private void Set(string action) => _status = action;
+    private void OnTab(string? title) => _status = $"Switched to {title} tab";
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeSheetTabsDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeSheetTabsDemo.razor
@@ -1,0 +1,28 @@
+@using Flare.Components.IDE
+
+@* FlareSheetTabs: the Excel sheet-tab strip - one pill per sheet plus an optional add button. It is
+   controlled: bind Sheets and ActiveIndex and handle OnAddSheet. The panel below reflects the
+   active sheet. *@
+<FlareStack Gap="FlareSpacing.Small">
+    <FlarePaper Elevation="0"
+                Style="height:120px;display:flex;align-items:center;justify-content:center;border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);">
+        <FlareText Typo="TypographyScale.TitleMedium">@_sheets[_active]</FlareText>
+    </FlarePaper>
+
+    <FlareSheetTabs Sheets="_sheets" @bind-ActiveIndex="_active" OnAddSheet="AddSheet" />
+
+    <FlareText Typo="TypographyScale.BodySmall" Color="FlareColor.OnSurfaceVariant">
+        Active sheet @(_active + 1) of @_sheets.Count - click <strong>+</strong> to add another.
+    </FlareText>
+</FlareStack>
+
+@code {
+    private readonly List<string> _sheets = ["Summary", "Q1", "Q2", "Budget"];
+    private int _active;
+
+    private void AddSheet()
+    {
+        _sheets.Add($"Sheet{_sheets.Count + 1}");
+        _active = _sheets.Count - 1;
+    }
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeStatusBarDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeStatusBarDemo.razor
@@ -1,0 +1,48 @@
+@using Flare.Components.IDE
+
+@* FlareStatusBar: a three-section bar (LeftContent / CenterContent / RightContent). Each slot is a
+   free render fragment, so it hosts plain text, icons, or interactive controls. Here the buttons
+   drive the values live. *@
+<FlareStack Gap="FlareSpacing.Small">
+    <div style="border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);overflow:hidden;">
+        <FlareStatusBar>
+            <LeftContent>
+                <span style="display:inline-flex;align-items:center;gap:0.35rem;">
+                    <FlareIcon Name="account_tree" Size="1rem" /> @_branch
+                </span>
+                <span>Ln @_line, Col @_col</span>
+            </LeftContent>
+            <CenterContent>@_message</CenterContent>
+            <RightContent>
+                <span>Spaces: @_indent</span>
+                <span>@_encoding</span>
+                <span>C#</span>
+            </RightContent>
+        </FlareStatusBar>
+    </div>
+
+    <FlareStack Row Gap="FlareSpacing.Small" Wrap>
+        <FlareButton Variant="ButtonVariant.Outlined" Size="ButtonSize.Sm" OnClick="MoveCursor">Move cursor</FlareButton>
+        <FlareButton Variant="ButtonVariant.Outlined" Size="ButtonSize.Sm" OnClick="@(() => _message = "Build succeeded")">Report build</FlareButton>
+        <FlareButton Variant="ButtonVariant.Outlined" Size="ButtonSize.Sm" OnClick="ToggleEncoding">Toggle encoding</FlareButton>
+        <FlareButton Variant="ButtonVariant.Outlined" Size="ButtonSize.Sm" OnClick="@(() => _branch = _branch == "main" ? "feature/ide" : "main")">Switch branch</FlareButton>
+    </FlareStack>
+</FlareStack>
+
+@code {
+    private string _branch = "main";
+    private int _line = 1;
+    private int _col = 1;
+    private int _indent = 4;
+    private string _encoding = "UTF-8";
+    private string _message = "Ready";
+
+    private void MoveCursor()
+    {
+        _line = Random.Shared.Next(1, 240);
+        _col = Random.Shared.Next(1, 80);
+        _message = $"Moved to line {_line}";
+    }
+
+    private void ToggleEncoding() => _encoding = _encoding == "UTF-8" ? "UTF-16 LE" : "UTF-8";
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeToolPanelDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/Examples/IdeToolPanelDemo.razor
@@ -1,0 +1,58 @@
+@using Flare.Components.IDE
+
+@* Standalone FlareToolPanel (outside a layout): a titled, collapsible dockable panel with an
+   optional header toolbar (ShowToolbar + ToolbarContent). Collapsing shrinks the panel to a thin
+   rail; bind Collapsed to drive it. Inside a FlareIdeLayout the layout owns collapse and the
+   auto-hide flyout instead - see the Full IDE Layout example. *@
+<div style="display:flex;gap:0.75rem;height:280px;align-items:stretch;">
+    <FlareToolPanel Title="Explorer" ShowToolbar="true"
+                    @bind-Collapsed="_explorerCollapsed"
+                    Style="width:240px;border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);">
+        <ToolbarContent>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Refresh">
+                <FlareIcon Name="refresh" />
+            </FlareButton>
+            <FlareButton Variant="ButtonVariant.Text" Size="ButtonSize.Xs" AriaLabel="Collapse all">
+                <FlareIcon Name="unfold_less" />
+            </FlareButton>
+        </ToolbarContent>
+        <ChildContent>
+            <FlareTreeView AriaLabel="Explorer">
+                <FlareTreeItem Label="src" Icon="folder" Expanded="true">
+                    <FlareTreeItem Label="Program.cs" Icon="description" />
+                    <FlareTreeItem Label="App.razor" Icon="code" />
+                </FlareTreeItem>
+                <FlareTreeItem Label="wwwroot" Icon="folder" />
+                <FlareTreeItem Label="README.md" Icon="article" />
+            </FlareTreeView>
+        </ChildContent>
+    </FlareToolPanel>
+
+    <FlareToolPanel Title="Outline"
+                    @bind-Collapsed="_outlineCollapsed"
+                    Style="width:240px;border:1px solid var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);">
+        <FlareList TItem="object">
+            <FlareListItem Primary="Main(string[] args)">
+                <Leading><FlareIcon Name="data_object" /></Leading>
+            </FlareListItem>
+            <FlareListItem Primary="ConfigureServices()">
+                <Leading><FlareIcon Name="data_object" /></Leading>
+            </FlareListItem>
+            <FlareListItem Primary="Configure(app)">
+                <Leading><FlareIcon Name="data_object" /></Leading>
+            </FlareListItem>
+        </FlareList>
+    </FlareToolPanel>
+
+    <FlarePaper Elevation="0"
+                Style="flex:1;display:flex;align-items:center;justify-content:center;border:1px dashed var(--flare-color-outline-variant);border-radius:var(--flare-shape-medium);">
+        <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodySmall">
+            Collapse a panel with its chevron - it frees space and shrinks to a rail.
+        </FlareText>
+    </FlarePaper>
+</div>
+
+@code {
+    private bool _explorerCollapsed;
+    private bool _outlineCollapsed = true;
+}

--- a/samples/Flare.Gallery/Pages/Components/IDE/IdePage.razor
+++ b/samples/Flare.Gallery/Pages/Components/IDE/IdePage.razor
@@ -54,6 +54,37 @@
     </FlareText>
 </FlareStack>
 
+<GallerySectionHeader Icon="widgets" Title="@GalleryStrings.Ide_BuildingBlocks" AnchorId="building-blocks" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_Ribbon_Title" Description="@GalleryStrings.Ide_Ribbon_Desc"
+    DemoType="typeof(Examples.IdeRibbonDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_DocTabs_Title" Description="@GalleryStrings.Ide_DocTabs_Desc"
+    DemoType="typeof(Examples.IdeDocumentTabsDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_ToolPanel_Title" Description="@GalleryStrings.Ide_ToolPanel_Desc"
+    DemoType="typeof(Examples.IdeToolPanelDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_CommandBars_Title" Description="@GalleryStrings.Ide_CommandBars_Desc"
+    DemoType="typeof(Examples.IdeCommandBarsDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_StatusBar_Title" Description="@GalleryStrings.Ide_StatusBar_Desc"
+    DemoType="typeof(Examples.IdeStatusBarDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_PropertyGrid_Title" Description="@GalleryStrings.Ide_PropertyGrid_Desc"
+    DemoType="typeof(Examples.IdePropertyGridDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_Backstage_Title" Description="@GalleryStrings.Ide_Backstage_Desc"
+    DemoType="typeof(Examples.IdeBackstageDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_FormulaBar_Title" Description="@GalleryStrings.Ide_FormulaBar_Desc"
+    DemoType="typeof(Examples.IdeFormulaBarDemo)" />
+
+<AutoDemoSection Title="@GalleryStrings.Ide_SheetTabs_Title" Description="@GalleryStrings.Ide_SheetTabs_Desc"
+    DemoType="typeof(Examples.IdeSheetTabsDemo)" />
+
+<GallerySectionHeader Icon="dashboard" Title="@GalleryStrings.Ide_FullShells" AnchorId="full-shells" />
+
 <AutoDemoSection Title="Full IDE Layout" DemoType="typeof(Examples.IdeLayoutDemo)"
     Description="Ribbon, explorer, document tabs, properties, a tabbed Output/Error/Terminal panel, and a status bar composed with FlareIdeLayout. Drag the dividers between regions to resize them (or focus a divider and use the arrow keys); collapse the explorer to a rail and try the auto-hide Properties flyout." />
 

--- a/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
@@ -4181,7 +4181,187 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Ide_Title", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Building blocks.
+        /// </summary>
+        public static string Ide_BuildingBlocks {
+            get {
+                return ResourceManager.GetString("Ide_BuildingBlocks", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Full compositions.
+        /// </summary>
+        public static string Ide_FullShells {
+            get {
+                return ResourceManager.GetString("Ide_FullShells", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Ribbon.
+        /// </summary>
+        public static string Ide_Ribbon_Title {
+            get {
+                return ResourceManager.GetString("Ide_Ribbon_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareRibbon with tabbed command groups....
+        /// </summary>
+        public static string Ide_Ribbon_Desc {
+            get {
+                return ResourceManager.GetString("Ide_Ribbon_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Document tabs.
+        /// </summary>
+        public static string Ide_DocTabs_Title {
+            get {
+                return ResourceManager.GetString("Ide_DocTabs_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Editor-style FlareDocumentTabs....
+        /// </summary>
+        public static string Ide_DocTabs_Desc {
+            get {
+                return ResourceManager.GetString("Ide_DocTabs_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Tool panel.
+        /// </summary>
+        public static string Ide_ToolPanel_Title {
+            get {
+                return ResourceManager.GetString("Ide_ToolPanel_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Standalone FlareToolPanel....
+        /// </summary>
+        public static string Ide_ToolPanel_Desc {
+            get {
+                return ResourceManager.GetString("Ide_ToolPanel_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Command bars.
+        /// </summary>
+        public static string Ide_CommandBars_Title {
+            get {
+                return ResourceManager.GetString("Ide_CommandBars_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareQuickAccessToolbar, FlareMenuBar....
+        /// </summary>
+        public static string Ide_CommandBars_Desc {
+            get {
+                return ResourceManager.GetString("Ide_CommandBars_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Status bar.
+        /// </summary>
+        public static string Ide_StatusBar_Title {
+            get {
+                return ResourceManager.GetString("Ide_StatusBar_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareStatusBar with three free-form sections....
+        /// </summary>
+        public static string Ide_StatusBar_Desc {
+            get {
+                return ResourceManager.GetString("Ide_StatusBar_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Property grid.
+        /// </summary>
+        public static string Ide_PropertyGrid_Title {
+            get {
+                return ResourceManager.GetString("Ide_PropertyGrid_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlarePropertyGrid rows....
+        /// </summary>
+        public static string Ide_PropertyGrid_Desc {
+            get {
+                return ResourceManager.GetString("Ide_PropertyGrid_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Backstage (File menu).
+        /// </summary>
+        public static string Ide_Backstage_Title {
+            get {
+                return ResourceManager.GetString("Ide_Backstage_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareBackstage: a full-surface File overlay....
+        /// </summary>
+        public static string Ide_Backstage_Desc {
+            get {
+                return ResourceManager.GetString("Ide_Backstage_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Formula bar.
+        /// </summary>
+        public static string Ide_FormulaBar_Title {
+            get {
+                return ResourceManager.GetString("Ide_FormulaBar_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareFormulaBar (Excel name box + fx + editor)....
+        /// </summary>
+        public static string Ide_FormulaBar_Desc {
+            get {
+                return ResourceManager.GetString("Ide_FormulaBar_Desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Sheet tabs.
+        /// </summary>
+        public static string Ide_SheetTabs_Title {
+            get {
+                return ResourceManager.GetString("Ide_SheetTabs_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareSheetTabs - the controlled Excel sheet-tab strip....
+        /// </summary>
+        public static string Ide_SheetTabs_Desc {
+            get {
+                return ResourceManager.GetString("Ide_SheetTabs_Desc", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Aspect Ratio &amp; Fluid.
         /// </summary>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.resx
@@ -582,6 +582,66 @@
   <data name="Ide_Subtitle" xml:space="preserve">
     <value>Compose a desktop-style IDE shell - ribbon, menu bar, document tabs, dockable tool panels, resizable splitter, and status bar - entirely from Flare components.</value>
   </data>
+  <data name="Ide_BuildingBlocks" xml:space="preserve">
+    <value>Building blocks</value>
+  </data>
+  <data name="Ide_FullShells" xml:space="preserve">
+    <value>Full compositions</value>
+  </data>
+  <data name="Ide_Ribbon_Title" xml:space="preserve">
+    <value>Ribbon</value>
+  </data>
+  <data name="Ide_Ribbon_Desc" xml:space="preserve">
+    <value>FlareRibbon with tabbed command groups, large (icon + label) and small (icon-only) buttons, an in-group separator, and a dropdown gallery. Toggle SizeMode to collapse the ribbon to its tab strip.</value>
+  </data>
+  <data name="Ide_DocTabs_Title" xml:space="preserve">
+    <value>Document tabs</value>
+  </data>
+  <data name="Ide_DocTabs_Desc" xml:space="preserve">
+    <value>Editor-style FlareDocumentTabs driven by a model list - a per-tab icon, a Modified indicator, a pinned (non-closeable) tab, plus add and close handling via OnTabChanged / OnTabClose.</value>
+  </data>
+  <data name="Ide_ToolPanel_Title" xml:space="preserve">
+    <value>Tool panel</value>
+  </data>
+  <data name="Ide_ToolPanel_Desc" xml:space="preserve">
+    <value>Standalone FlareToolPanel: a titled, collapsible dockable panel with an optional header toolbar. Collapsing shrinks it to a thin rail. Inside a layout the layout owns collapse and the auto-hide flyout.</value>
+  </data>
+  <data name="Ide_CommandBars_Title" xml:space="preserve">
+    <value>Command bars</value>
+  </data>
+  <data name="Ide_CommandBars_Desc" xml:space="preserve">
+    <value>FlareQuickAccessToolbar, FlareMenuBar with dropdown menus, and a FlareToolbar icon command bar with separators and an inline field. Toggle Dense to tighten the toolbar.</value>
+  </data>
+  <data name="Ide_StatusBar_Title" xml:space="preserve">
+    <value>Status bar</value>
+  </data>
+  <data name="Ide_StatusBar_Desc" xml:space="preserve">
+    <value>FlareStatusBar with three free-form sections (left / center / right) hosting text, icons, or interactive controls. The buttons drive the values live.</value>
+  </data>
+  <data name="Ide_PropertyGrid_Title" xml:space="preserve">
+    <value>Property grid</value>
+  </data>
+  <data name="Ide_PropertyGrid_Desc" xml:space="preserve">
+    <value>FlarePropertyGrid rows whose values are real Flare inputs (field, select, checkbox, switch, numeric) bound to a model - here the sheet drives the live button preview.</value>
+  </data>
+  <data name="Ide_Backstage_Title" xml:space="preserve">
+    <value>Backstage (File menu)</value>
+  </data>
+  <data name="Ide_Backstage_Desc" xml:space="preserve">
+    <value>FlareBackstage: a full-surface File overlay with a navigation rail and content area. Open it with File, pick a rail entry to switch content, and use the back arrow to close.</value>
+  </data>
+  <data name="Ide_FormulaBar_Title" xml:space="preserve">
+    <value>Formula bar</value>
+  </data>
+  <data name="Ide_FormulaBar_Desc" xml:space="preserve">
+    <value>FlareFormulaBar (Excel name box + fx + editor), built on FlareField. Click a cell to load it into the bar; edit the formula to write it back to the selected cell.</value>
+  </data>
+  <data name="Ide_SheetTabs_Title" xml:space="preserve">
+    <value>Sheet tabs</value>
+  </data>
+  <data name="Ide_SheetTabs_Desc" xml:space="preserve">
+    <value>FlareSheetTabs - the controlled Excel sheet-tab strip with an add button. Bind Sheets and ActiveIndex and handle OnAddSheet.</value>
+  </data>
   <data name="DataGrid_PersistenceTitle" xml:space="preserve">
     <value>State Persistence</value>
   </data>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
@@ -582,6 +582,66 @@
   <data name="Ide_Subtitle" xml:space="preserve">
     <value>Соберите оболочку IDE в стиле десктоп-приложения - лента, строка меню, вкладки документов, закрепляемые панели инструментов, изменяемый разделитель и строка состояния - целиком из компонентов Flare.</value>
   </data>
+  <data name="Ide_BuildingBlocks" xml:space="preserve">
+    <value>Строительные блоки</value>
+  </data>
+  <data name="Ide_FullShells" xml:space="preserve">
+    <value>Полные оболочки</value>
+  </data>
+  <data name="Ide_Ribbon_Title" xml:space="preserve">
+    <value>Лента</value>
+  </data>
+  <data name="Ide_Ribbon_Desc" xml:space="preserve">
+    <value>FlareRibbon с вкладками групп команд, большими (значок + подпись) и малыми (только значок) кнопками, разделителем внутри группы и выпадающей галереей. Переключите SizeMode, чтобы свернуть ленту до полосы вкладок.</value>
+  </data>
+  <data name="Ide_DocTabs_Title" xml:space="preserve">
+    <value>Вкладки документов</value>
+  </data>
+  <data name="Ide_DocTabs_Desc" xml:space="preserve">
+    <value>Вкладки FlareDocumentTabs в стиле редактора на основе списка-модели - значок у каждой вкладки, индикатор изменений, закреплённая (незакрываемая) вкладка, добавление и закрытие через OnTabChanged / OnTabClose.</value>
+  </data>
+  <data name="Ide_ToolPanel_Title" xml:space="preserve">
+    <value>Панель инструментов</value>
+  </data>
+  <data name="Ide_ToolPanel_Desc" xml:space="preserve">
+    <value>Автономная FlareToolPanel: закрепляемая сворачиваемая панель с заголовком и необязательной панелью инструментов в шапке. При сворачивании она сжимается до тонкой полосы. Внутри макета сворачиванием и всплывающей панелью управляет сам макет.</value>
+  </data>
+  <data name="Ide_CommandBars_Title" xml:space="preserve">
+    <value>Командные панели</value>
+  </data>
+  <data name="Ide_CommandBars_Desc" xml:space="preserve">
+    <value>FlareQuickAccessToolbar, FlareMenuBar с выпадающими меню и панель команд FlareToolbar со значками, разделителями и встроенным полем. Переключите Dense, чтобы уплотнить панель.</value>
+  </data>
+  <data name="Ide_StatusBar_Title" xml:space="preserve">
+    <value>Строка состояния</value>
+  </data>
+  <data name="Ide_StatusBar_Desc" xml:space="preserve">
+    <value>FlareStatusBar с тремя свободными секциями (слева / по центру / справа) для текста, значков или интерактивных элементов. Кнопки меняют значения в реальном времени.</value>
+  </data>
+  <data name="Ide_PropertyGrid_Title" xml:space="preserve">
+    <value>Сетка свойств</value>
+  </data>
+  <data name="Ide_PropertyGrid_Desc" xml:space="preserve">
+    <value>Строки FlarePropertyGrid, значения которых - настоящие поля Flare (поле, выбор, флажок, переключатель, число), привязанные к модели; здесь сетка управляет живым предпросмотром кнопки.</value>
+  </data>
+  <data name="Ide_Backstage_Title" xml:space="preserve">
+    <value>Backstage (меню Файл)</value>
+  </data>
+  <data name="Ide_Backstage_Desc" xml:space="preserve">
+    <value>FlareBackstage: полноэкранное меню Файл с панелью навигации и областью содержимого. Откройте кнопкой Файл, выберите пункт слева для смены содержимого и закройте стрелкой назад.</value>
+  </data>
+  <data name="Ide_FormulaBar_Title" xml:space="preserve">
+    <value>Строка формул</value>
+  </data>
+  <data name="Ide_FormulaBar_Desc" xml:space="preserve">
+    <value>FlareFormulaBar (поле имени Excel + fx + редактор) на основе FlareField. Щёлкните ячейку, чтобы загрузить её в строку; измените формулу, и она запишется в выбранную ячейку.</value>
+  </data>
+  <data name="Ide_SheetTabs_Title" xml:space="preserve">
+    <value>Вкладки листов</value>
+  </data>
+  <data name="Ide_SheetTabs_Desc" xml:space="preserve">
+    <value>FlareSheetTabs - управляемая полоса вкладок листов Excel с кнопкой добавления. Привяжите Sheets и ActiveIndex и обработайте OnAddSheet.</value>
+  </data>
   <data name="DataGrid_PersistenceTitle" xml:space="preserve">
     <value>Сохранение состояния</value>
   </data>


### PR DESCRIPTION
<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
