### PR TITLE
Feat: component-dialog service (IDialogService.ShowAsync<TComponent>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to Flare are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.0.7] - 2026-06-30
+
+This release adds a **generic component-dialog service**: render any Blazor component as a modal and
+await a typed result, instead of the inline `@bind-Visible` plumbing previously required.
+
+### Added
+- **`IDialogService.ShowAsync<TComponent>` / `Show<TComponent>`** - open any component as a modal
+  dialog body and await its outcome. `ShowAsync` returns a `Task<DialogResult>`; `Show` returns a
+  `DialogReference` whose `Result` can be awaited and which can also close the dialog from the caller
+  side. The body component receives a cascaded `FlareDialogInstance` to close itself
+  (`Dialog.Close(value)` / `Dialog.Cancel()`), and the dialog is rendered through the existing
+  `FlareDialogProvider` (a `DynamicComponent` host) with the same visuals, sizing, scrim, focus-trap
+  and Escape handling as `FlareDialog`.
+- **`DialogParameters`** - a fluent bag (`Add(name, value)`) binding values to the body component's
+  `[Parameter]`s; **`DialogResult`** (`Ok(payload)` / `Cancel()` with `Cancelled` and a typed
+  `GetData<T>()`); and **`DialogOptions`** (`Size`, `CloseOnScrimClick`, `CloseOnEsc`, `Divider`).
+- Gallery: a new **Component dialog** demo on the Dialog page (an edit-profile dialog that receives
+  initial values and returns an edited model).
+
+### Changed
+- **`DialogSize` moved from the `Flare.Components` namespace to `Flare.Abstractions`** (it is now a
+  shared dialog contract used by `DialogOptions`). Code that imports both namespaces (the usual setup)
+  is unaffected; code that referenced `Flare.Components.DialogSize` by its full name should update the
+  namespace. The existing `ConfirmAsync` / `AlertAsync` helpers are unchanged.
+
 ## [0.0.6] - 2026-06-30
 
 This release reworks the **layout and navigation API** - a breaking change - and adds a large batch

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -246,6 +246,39 @@ Flare integrates fully with Blazor's standard `EditContext`:
 }
 ```
 
+Need more than confirm/alert? `ShowAsync<TComponent>` renders **any** component as a modal and
+returns a typed result - no inline `@bind-Visible` plumbing:
+
+```razor
+@inject IDialogService Dialog
+
+@code {
+    private async Task Edit(Person person)
+    {
+        var parameters = new DialogParameters()
+            .Add(nameof(PersonEditDialog.Person), person);
+
+        var result = await Dialog.ShowAsync<PersonEditDialog>(
+            "Edit profile", parameters, new DialogOptions { Size = DialogSize.Sm });
+
+        if (!result.Cancelled && result.GetData<Person>() is { } edited)
+            Apply(edited);
+    }
+}
+```
+
+The dialog body closes itself through a cascaded `FlareDialogInstance`:
+
+```razor
+@code {
+    [CascadingParameter] public FlareDialogInstance Dialog { get; set; } = default!;
+    [Parameter] public Person Person { get; set; } = default!;
+
+    private void Save()   => Dialog.Close(_edited); // confirm with a typed payload
+    private void Cancel() => Dialog.Cancel();        // dismiss
+}
+```
+
 ---
 
 ## 10. Docker

--- a/docs/ru/getting-started.md
+++ b/docs/ru/getting-started.md
@@ -247,6 +247,39 @@ Flare полностью интегрируется со стандартным 
 }
 ```
 
+Нужно больше, чем confirm/alert? `ShowAsync<TComponent>` показывает **любой** компонент как
+модальное окно и возвращает типизированный результат - без встроенного `@bind-Visible`:
+
+```razor
+@inject IDialogService Dialog
+
+@code {
+    private async Task Edit(Person person)
+    {
+        var parameters = new DialogParameters()
+            .Add(nameof(PersonEditDialog.Person), person);
+
+        var result = await Dialog.ShowAsync<PersonEditDialog>(
+            "Изменить профиль", parameters, new DialogOptions { Size = DialogSize.Sm });
+
+        if (!result.Cancelled && result.GetData<Person>() is { } edited)
+            Apply(edited);
+    }
+}
+```
+
+Тело диалога закрывает себя через каскадный `FlareDialogInstance`:
+
+```razor
+@code {
+    [CascadingParameter] public FlareDialogInstance Dialog { get; set; } = default!;
+    [Parameter] public Person Person { get; set; } = default!;
+
+    private void Save()   => Dialog.Close(_edited); // подтвердить с типизированным результатом
+    private void Cancel() => Dialog.Cancel();        // отклонить
+}
+```
+
 ---
 
 ## 10. Docker

--- a/samples/Flare.Gallery/Api/ComponentApiRegistry.g.cs
+++ b/samples/Flare.Gallery/Api/ComponentApiRegistry.g.cs
@@ -5396,9 +5396,9 @@ public static class ComponentApiRegistry
 
         e[@"DialogSize"] = new ApiEnumInfo(
             @"DialogSize",
-            @"Flare.Components.DialogSize",
-            @"Flare.Components",
-            @"Maximum-width size presets for FlareDialog.",
+            @"Flare.Abstractions.DialogSize",
+            @"Flare.Abstractions",
+            @"Maximum-width size presets for a Flare dialog (FlareDialog / a component dialog).",
             null,
             new ApiEnumMember[]
             {

--- a/samples/Flare.Gallery/Layout/MainLayout.razor
+++ b/samples/Flare.Gallery/Layout/MainLayout.razor
@@ -15,7 +15,7 @@
                     <FlareText Typo="TypographyScale.TitleLarge" Weight="FontWeight.ExtraBold" Style="letter-spacing:-0.5px;">Flare</FlareText>
                 </FlareStack>
             </FlareLink>
-            <FlareBadge Text="v0.0.6" Standalone="true" Color="FlareColor.Secondary" />
+            <FlareBadge Text="v0.0.7" Standalone="true" Color="FlareColor.Secondary" />
             <FlareSpacer />
             <GallerySearch />
             <FlareSpacer />

--- a/samples/Flare.Gallery/Layout/SecondaryNav.razor
+++ b/samples/Flare.Gallery/Layout/SecondaryNav.razor
@@ -36,6 +36,7 @@
             <FlareNavLink Href="/services/snackbar">Snackbar</FlareNavLink>
             <FlareNavLink Href="/services/download">Download</FlareNavLink>
             <FlareNavLink Href="/services/messagebox">Message Box</FlareNavLink>
+            <FlareNavLink Href="/services/dialog">Dialog</FlareNavLink>
             <FlareNavLink Href="/services/version-check">Version Check</FlareNavLink>
         }
         else if (Section == GallerySection.Api)

--- a/samples/Flare.Gallery/Pages/About.razor
+++ b/samples/Flare.Gallery/Pages/About.razor
@@ -44,6 +44,18 @@
 <section>
     <GallerySectionHeader Icon="new_releases" Title="@GalleryStrings.About_WhatsNew" />
     <FlareCard Variant="CardVariant.Outlined" Style="margin-bottom:1rem;">
+        <FlareText Typo="TypographyScale.TitleMedium" Style="margin-bottom:0.75rem;">v0.0.7 - 2026-06-30</FlareText>
+        <FlareStack Gap="FlareSpacing.XSmall" Align="FlareAlignItems.Start">
+            @foreach (var item in _whatsNewV7)
+            {
+                <FlareStack Row Gap="FlareSpacing.XSmall" Align="FlareAlignItems.Start">
+                    <FlareIcon Size="1rem" Color="FlareColor.Primary" Name="check_circle" Style="margin-top:2px" />
+                    <FlareText Typo="TypographyScale.BodyMedium">@item</FlareText>
+                </FlareStack>
+            }
+        </FlareStack>
+    </FlareCard>
+    <FlareCard Variant="CardVariant.Outlined" Style="margin-bottom:1rem;">
         <FlareText Typo="TypographyScale.TitleMedium" Style="margin-bottom:0.75rem;">v0.0.6 - 2026-06-30</FlareText>
         <FlareStack Gap="FlareSpacing.XSmall" Align="FlareAlignItems.Start">
             @foreach (var item in _whatsNewV6)
@@ -132,7 +144,7 @@
 </FlareStack>
 
 @code {
-    private readonly string _version = "0.0.6";
+    private readonly string _version = "0.0.7";
 
     private void GoToGitHub() => Nav.NavigateTo("https://github.com/jrfrigat/Flare", forceLoad: true);
 
@@ -140,6 +152,7 @@
     private static string[] Lines(string value) =>
         value.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
+    private string[] _whatsNewV7 => Lines(GalleryStrings.About_WhatsNewV7);
     private string[] _whatsNewV6 => Lines(GalleryStrings.About_WhatsNewV6);
     private string[] _whatsNewV5 => Lines(GalleryStrings.About_WhatsNewV5);
     private string[] _whatsNewV4 => Lines(GalleryStrings.About_WhatsNewV4);

--- a/samples/Flare.Gallery/Pages/Components/Dialog/DialogPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Dialog/DialogPage.razor
@@ -11,6 +11,8 @@
     <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodyLarge">@GalleryStrings.Dialog_Subtitle</FlareText>
 </GalleryPageTitle>
 
+<AutoDemoSection Title="@GalleryStrings.Dialog_Component" DemoType="typeof(Examples.DialogComponentDemo)" />
+
 <AutoDemoSection Title="@GalleryStrings.Dialog_Inline" DemoType="typeof(Examples.DialogInlineDemo)" />
 
 <AutoDemoSection Title="@GalleryStrings.Dialog_Icon" DemoType="typeof(Examples.DialogIconDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Dialog/Examples/DialogComponentDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Dialog/Examples/DialogComponentDemo.razor
@@ -1,0 +1,45 @@
+@inject IDialogService DialogService
+@inject ISnackbarService Snackbar
+@inherits LocalizedPage
+
+@* Opens an arbitrary component (PersonEditDialog) as a modal and awaits a typed result, with no
+   inline @bind-Visible markup on this page - the dialog body owns its own lifecycle. *@
+<FlareStack Gap="FlareSpacing.Medium" Align="FlareAlignItems.Start">
+    <FlareText Typo="TypographyScale.BodyMedium" Color="FlareColor.OnSurfaceVariant">
+        @_name (@_email)
+    </FlareText>
+    <FlareButton Variant="ButtonVariant.Filled" OnClick="EditProfile">
+        <LeadingIcon><FlareIcon Name="edit" /></LeadingIcon>
+        <ChildContent>@GalleryStrings.Dialog_EditProfile</ChildContent>
+    </FlareButton>
+</FlareStack>
+
+@code {
+    private string _name = "Ada Lovelace";
+    private string _email = "ada@example.com";
+
+    private async Task EditProfile()
+    {
+        var parameters = new DialogParameters()
+            .Add(nameof(PersonEditDialog.Name), _name)
+            .Add(nameof(PersonEditDialog.Email), _email);
+
+        var result = await DialogService.ShowAsync<PersonEditDialog>(
+            GalleryStrings.Dialog_EditProfile,
+            parameters,
+            new DialogOptions { Size = DialogSize.Sm });
+
+        if (result.Cancelled)
+        {
+            Snackbar.Show(GalleryStrings.Dialog_Cancelled, SnackbarSeverity.Normal);
+            return;
+        }
+
+        if (result.GetData<PersonEditDialog.Profile>() is { } profile)
+        {
+            _name = profile.Name;
+            _email = profile.Email;
+            Snackbar.Show(string.Format(GalleryStrings.Dialog_ProfileSaved, profile.Name), SnackbarSeverity.Success);
+        }
+    }
+}

--- a/samples/Flare.Gallery/Pages/Components/Dialog/Examples/PersonEditDialog.razor
+++ b/samples/Flare.Gallery/Pages/Components/Dialog/Examples/PersonEditDialog.razor
@@ -1,0 +1,45 @@
+@inherits LocalizedPage
+
+@* A reusable dialog body. It receives its initial values as [Parameter]s and closes itself with a
+   typed result through the cascaded FlareDialogInstance - no @bind-Visible plumbing on the caller. *@
+<FlareStack Gap="FlareSpacing.Medium" Style="min-width:18rem;">
+    <FlareTextField @bind-Value="_name" Label="@GalleryStrings.Dialog_Name" Variant="InputVariant.Outlined" />
+    <FlareTextField @bind-Value="_email" Label="@GalleryStrings.Dialog_Email" Variant="InputVariant.Outlined" />
+    <FlareStack Row Gap="FlareSpacing.Small" Justify="FlareJustifyContent.End">
+        <FlareButton Variant="ButtonVariant.Text" OnClick="@(() => Dialog.Cancel())">
+            @GalleryStrings.Dialog_BodyCancel
+        </FlareButton>
+        <FlareButton Variant="ButtonVariant.Filled" OnClick="Save">
+            @GalleryStrings.Dialog_Save
+        </FlareButton>
+    </FlareStack>
+</FlareStack>
+
+@code {
+    /// <summary>The live dialog handle, cascaded by FlareDialogProvider. Used to close with a result.</summary>
+    [CascadingParameter] public FlareDialogInstance Dialog { get; set; } = default!;
+
+    /// <summary>Initial name shown in the editor.</summary>
+    [Parameter] public string Name { get; set; } = "";
+
+    /// <summary>Initial email shown in the editor.</summary>
+    [Parameter] public string Email { get; set; } = "";
+
+    private string _name = "";
+    private string _email = "";
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        // Edit working copies so a cancel leaves the caller's values untouched.
+        _name = Name;
+        _email = Email;
+    }
+
+    private void Save() => Dialog.Close(new Profile(_name, _email));
+
+    /// <summary>The typed payload this dialog returns via DialogResult on save.</summary>
+    /// <param name="Name">The edited name.</param>
+    /// <param name="Email">The edited email.</param>
+    public record Profile(string Name, string Email);
+}

--- a/samples/Flare.Gallery/Pages/Services/DialogServicePage.razor
+++ b/samples/Flare.Gallery/Pages/Services/DialogServicePage.razor
@@ -1,0 +1,91 @@
+@page "/services/dialog"
+@using Flare.Gallery.Pages.Components.Dialog.Examples
+@inherits LocalizedPage
+@inject IDialogService Dialog
+@inject ISnackbarService Snackbar
+
+<PageTitle>@GalleryStrings.Services_DialogTitle - Flare</PageTitle>
+
+<GalleryPageTitle Package="Flare.Blazor">
+    <FlareText Typo="TypographyScale.HeadlineMedium">@GalleryStrings.Services_DialogTitle</FlareText>
+    <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodyLarge">@GalleryStrings.Services_DialogSubtitle</FlareText>
+</GalleryPageTitle>
+
+<FlareCard Variant="CardVariant.Outlined">
+    <FlareStack Gap="FlareSpacing.Medium">
+        <FlareStack Row Wrap Gap="FlareSpacing.Small">
+            <FlareButton OnClick="ShowComponentDialog">@GalleryStrings.Dialog_Component</FlareButton>
+            <FlareButton Variant="ButtonVariant.Tonal" OnClick="ConfirmAsync">@GalleryStrings.Services_Confirm</FlareButton>
+            <FlareButton Variant="ButtonVariant.Outlined" OnClick="AlertAsync">@GalleryStrings.Services_Alert</FlareButton>
+        </FlareStack>
+        @if (_result is not null)
+        {
+            <FlareText Typo="TypographyScale.BodyMedium">@GalleryStrings.Services_Result <code>@_result</code></FlareText>
+        }
+    </FlareStack>
+</FlareCard>
+
+<FlareText Typo="TypographyScale.TitleSmall" Style="margin:1.75rem 0 0.5rem">@GalleryStrings.Services_Usage</FlareText>
+<FlareCodeBlock Value="@_usage" Language="razor" ReadOnly="true" LineNumbers="true" />
+
+@code {
+    private string? _result;
+
+    private const string _usage = """
+        @inject IDialogService Dialog
+
+        @code {
+            async Task Edit(Person person)
+            {
+                // Render any component as a modal and await a typed result.
+                var parameters = new DialogParameters()
+                    .Add(nameof(PersonEditDialog.Name), person.Name)
+                    .Add(nameof(PersonEditDialog.Email), person.Email);
+
+                var result = await Dialog.ShowAsync<PersonEditDialog>(
+                    "Edit profile", parameters, new DialogOptions { Size = DialogSize.Sm });
+
+                if (!result.Cancelled && result.GetData<PersonEditDialog.Profile>() is { } edited)
+                    Apply(edited); // edited.Name / edited.Email
+            }
+        }
+
+        @* The dialog body closes itself through a cascaded FlareDialogInstance: *@
+        @* [CascadingParameter] FlareDialogInstance Dialog { get; set; }       *@
+        @* Dialog.Close(new Profile(name, email));  // or Dialog.Cancel();     *@
+        """;
+
+    private async Task ShowComponentDialog()
+    {
+        var parameters = new DialogParameters()
+            .Add(nameof(PersonEditDialog.Name), "Ada Lovelace")
+            .Add(nameof(PersonEditDialog.Email), "ada@example.com");
+
+        var result = await Dialog.ShowAsync<PersonEditDialog>(
+            GalleryStrings.Dialog_EditProfile, parameters, new DialogOptions { Size = DialogSize.Sm });
+
+        if (result.Cancelled)
+        {
+            _result = GalleryStrings.Dialog_Cancelled;
+            return;
+        }
+
+        if (result.GetData<PersonEditDialog.Profile>() is { } profile)
+        {
+            _result = $"{profile.Name} ({profile.Email})";
+            Snackbar.Show(string.Format(GalleryStrings.Dialog_ProfileSaved, profile.Name), SnackbarSeverity.Success);
+        }
+    }
+
+    private async Task ConfirmAsync()
+    {
+        var confirmed = await Dialog.ConfirmAsync("Delete item?", "This action cannot be undone.", "Delete", "Cancel");
+        _result = confirmed?.ToString() ?? "(dismissed)";
+    }
+
+    private async Task AlertAsync()
+    {
+        await Dialog.AlertAsync("Heads up", "Your changes have been saved.");
+        _result = "dismissed";
+    }
+}

--- a/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
@@ -203,7 +203,16 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("About_WhatsNewV6", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Component dialogs: IDialogService.ShowAsync&lt;TComponent&gt; renders any component as a modal and returns a typed DialogResult.
+        /// </summary>
+        public static string About_WhatsNewV7 {
+            get {
+                return ResourceManager.GetString("About_WhatsNewV7", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Basic (single expand).
         /// </summary>
@@ -2876,7 +2885,34 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Dialog_Alert", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Cancel.
+        /// </summary>
+        public static string Dialog_BodyCancel {
+            get {
+                return ResourceManager.GetString("Dialog_BodyCancel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Cancelled.
+        /// </summary>
+        public static string Dialog_Cancelled {
+            get {
+                return ResourceManager.GetString("Dialog_Cancelled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Component dialog.
+        /// </summary>
+        public static string Dialog_Component {
+            get {
+                return ResourceManager.GetString("Dialog_Component", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Confirm.
         /// </summary>
@@ -2885,7 +2921,25 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Dialog_Confirm", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Edit profile.
+        /// </summary>
+        public static string Dialog_EditProfile {
+            get {
+                return ResourceManager.GetString("Dialog_EditProfile", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Email.
+        /// </summary>
+        public static string Dialog_Email {
+            get {
+                return ResourceManager.GetString("Dialog_Email", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Hero icon &amp; divider.
         /// </summary>
@@ -2903,7 +2957,25 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Dialog_Inline", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Name.
+        /// </summary>
+        public static string Dialog_Name {
+            get {
+                return ResourceManager.GetString("Dialog_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Profile saved: {0}.
+        /// </summary>
+        public static string Dialog_ProfileSaved {
+            get {
+                return ResourceManager.GetString("Dialog_ProfileSaved", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Prompt.
         /// </summary>
@@ -2912,7 +2984,16 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Dialog_Prompt", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Save.
+        /// </summary>
+        public static string Dialog_Save {
+            get {
+                return ResourceManager.GetString("Dialog_Save", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Show alert dialog.
         /// </summary>
@@ -6368,7 +6449,25 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Services_MsgBoxSubtitle", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Dialog service.
+        /// </summary>
+        public static string Services_DialogTitle {
+            get {
+                return ResourceManager.GetString("Services_DialogTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на IDialogService - render any component as a modal and await a typed result, plus awaitable Confirm / Alert.
+        /// </summary>
+        public static string Services_DialogSubtitle {
+            get {
+                return ResourceManager.GetString("Services_DialogSubtitle", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Message box service.
         /// </summary>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.resx
@@ -844,7 +844,31 @@
     <value>Dialog</value>
   </data>
   <data name="Dialog_Subtitle" xml:space="preserve">
-    <value>Inline @bind-Visible dialog, service-based confirm and alert.</value>
+    <value>Render any component as a modal via the dialog service, plus inline @bind-Visible, confirm and alert.</value>
+  </data>
+  <data name="Dialog_Component" xml:space="preserve">
+    <value>Component dialog</value>
+  </data>
+  <data name="Dialog_EditProfile" xml:space="preserve">
+    <value>Edit profile</value>
+  </data>
+  <data name="Dialog_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Dialog_Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Dialog_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Dialog_BodyCancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Dialog_Cancelled" xml:space="preserve">
+    <value>Cancelled</value>
+  </data>
+  <data name="Dialog_ProfileSaved" xml:space="preserve">
+    <value>Profile saved: {0}</value>
   </data>
   <data name="Dialog_Inline" xml:space="preserve">
     <value>Inline</value>
@@ -2379,6 +2403,12 @@
   <data name="About_Intro" xml:space="preserve">
     <value>Flare is an open-source Blazor component library built with .NET 10.</value>
   </data>
+  <data name="About_WhatsNewV7" xml:space="preserve">
+    <value>Component dialogs: IDialogService.ShowAsync&lt;TComponent&gt; renders any component as a modal and returns a typed DialogResult - no inline @bind-Visible plumbing
+Pass values in with a DialogParameters bag and close from the body via the cascaded FlareDialogInstance (Dialog.Close(value) / Dialog.Cancel())
+DialogOptions controls the size, scrim/Escape dismissal and the header divider; the existing confirm and alert helpers are unchanged
+Gallery: a new Component dialog demo on the Dialog page</value>
+  </data>
   <data name="About_WhatsNewV6" xml:space="preserve">
     <value>Layout and navigation redesigned: each FlareLayoutDrawer now owns its own state (@bind-Open) with a Variant, so you can compose multi-drawer (two-pane) layouts, and FlareNavMenu gains Full/Rail/RailLabeled modes (a breaking change to the old slot-based FlareLayout)
 FlareDateRangePicker gains an inline range-calendar mode, Min/Max/IsDateDisabled constraints, and public DefaultPresets you can extend
@@ -2512,6 +2542,8 @@ Gallery rebuilt entirely on Flare components - no raw divs or magic code</value>
   <data name="Services_DownloadSubtitle" xml:space="preserve"><value>IFlareDownload triggers a client-side file download from in-memory content (text, CSV with BOM, etc.).</value></data>
   <data name="Services_MsgBoxTitle" xml:space="preserve"><value>Message box service</value></data>
   <data name="Services_MsgBoxSubtitle" xml:space="preserve"><value>IMessageBoxService - awaitable Confirm / Alert / Prompt dialogs from C#, no markup required.</value></data>
+  <data name="Services_DialogTitle" xml:space="preserve"><value>Dialog service</value></data>
+  <data name="Services_DialogSubtitle" xml:space="preserve"><value>IDialogService - render any component as a modal and await a typed result, plus awaitable Confirm / Alert.</value></data>
   <data name="Services_Copy" xml:space="preserve"><value>Copy</value></data>
   <data name="Services_Read" xml:space="preserve"><value>Read</value></data>
   <data name="Services_WithAction" xml:space="preserve"><value>With action</value></data>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
@@ -844,7 +844,31 @@
     <value>Диалог</value>
   </data>
   <data name="Dialog_Subtitle" xml:space="preserve">
-    <value>Встроенный диалог @bind-Visible, диалоги через сервис.</value>
+    <value>Показ любого компонента как модального окна через сервис диалогов, плюс встроенный @bind-Visible, подтверждение и оповещение.</value>
+  </data>
+  <data name="Dialog_Component" xml:space="preserve">
+    <value>Компонентный диалог</value>
+  </data>
+  <data name="Dialog_EditProfile" xml:space="preserve">
+    <value>Редактировать профиль</value>
+  </data>
+  <data name="Dialog_Name" xml:space="preserve">
+    <value>Имя</value>
+  </data>
+  <data name="Dialog_Email" xml:space="preserve">
+    <value>Эл. почта</value>
+  </data>
+  <data name="Dialog_Save" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="Dialog_BodyCancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="Dialog_Cancelled" xml:space="preserve">
+    <value>Отменено</value>
+  </data>
+  <data name="Dialog_ProfileSaved" xml:space="preserve">
+    <value>Профиль сохранён: {0}</value>
   </data>
   <data name="Dialog_Inline" xml:space="preserve">
     <value>Встроенный</value>
@@ -2379,6 +2403,12 @@
   <data name="About_Intro" xml:space="preserve">
     <value>Flare - библиотека компонентов Blazor с открытым исходным кодом на .NET 10.</value>
   </data>
+  <data name="About_WhatsNewV7" xml:space="preserve">
+    <value>Компонентные диалоги: IDialogService.ShowAsync&lt;TComponent&gt; показывает любой компонент как модальное окно и возвращает типизированный DialogResult - без встроенного @bind-Visible
+Передавайте значения через набор DialogParameters и закрывайте диалог из тела через каскадный FlareDialogInstance (Dialog.Close(value) / Dialog.Cancel())
+DialogOptions управляет размером, закрытием по фону/Escape и разделителем заголовка; прежние помощники подтверждения и оповещения не изменились
+Галерея: новое демо компонентного диалога на странице Диалог</value>
+  </data>
   <data name="About_WhatsNewV6" xml:space="preserve">
     <value>Переработаны макет и навигация: каждый FlareLayoutDrawer теперь сам владеет своим состоянием (@bind-Open) и имеет Variant, поэтому можно собирать макеты с несколькими панелями (две колонки), а FlareNavMenu получает режимы Full/Rail/RailLabeled (ломающее изменение прежнего слотового FlareLayout)
 FlareDateRangePicker получает встроенный режим календаря диапазона, ограничения Min/Max/IsDateDisabled и публичные DefaultPresets, которые можно дополнять
@@ -2512,6 +2542,8 @@ MarkdownParser: защита от vbscript/data-uri/expression()/опасных 
   <data name="Services_DownloadSubtitle" xml:space="preserve"><value>IFlareDownload скачивает файл на клиенте из данных в памяти (текст, CSV с BOM и т.д.).</value></data>
   <data name="Services_MsgBoxTitle" xml:space="preserve"><value>Сервис диалогов</value></data>
   <data name="Services_MsgBoxSubtitle" xml:space="preserve"><value>IMessageBoxService - ожидаемые из C# диалоги Confirm / Alert / Prompt без разметки.</value></data>
+  <data name="Services_DialogTitle" xml:space="preserve"><value>Сервис диалоговых окон</value></data>
+  <data name="Services_DialogSubtitle" xml:space="preserve"><value>IDialogService - показ любого компонента как модального окна с типизированным результатом, плюс ожидаемые Confirm / Alert.</value></data>
   <data name="Services_Copy" xml:space="preserve"><value>Копировать</value></data>
   <data name="Services_Read" xml:space="preserve"><value>Прочитать</value></data>
   <data name="Services_WithAction" xml:space="preserve"><value>С действием</value></data>

--- a/src/Flare.Abstractions/Abstractions/DialogOptions.cs
+++ b/src/Flare.Abstractions/Abstractions/DialogOptions.cs
@@ -1,0 +1,29 @@
+namespace Flare.Abstractions;
+
+/// <summary>
+/// Presentation options for a component dialog opened via
+/// <see cref="IDialogService.ShowAsync{TComponent}"/> / <see cref="IDialogService.Show{TComponent}"/>.
+/// </summary>
+public sealed class DialogOptions
+{
+    /// <summary>The maximum-width preset. Defaults to <see cref="DialogSize.Md"/>.</summary>
+    public DialogSize Size { get; set; } = DialogSize.Md;
+
+    /// <summary>
+    /// Dismisses the dialog (resolving as <see cref="DialogResult.Cancel"/>) when the scrim backdrop
+    /// is clicked. Default <see langword="true"/>.
+    /// </summary>
+    public bool CloseOnScrimClick { get; set; } = true;
+
+    /// <summary>
+    /// Dismisses the dialog (resolving as <see cref="DialogResult.Cancel"/>) when the Escape key is
+    /// pressed. Default <see langword="true"/>.
+    /// </summary>
+    public bool CloseOnEsc { get; set; } = true;
+
+    /// <summary>Shows a divider between the title header and the body. Default <see langword="false"/>.</summary>
+    public bool Divider { get; set; }
+
+    /// <summary>Shared, immutable-by-convention default options used when a caller supplies none.</summary>
+    public static DialogOptions Default { get; } = new();
+}

--- a/src/Flare.Abstractions/Abstractions/DialogParameters.cs
+++ b/src/Flare.Abstractions/Abstractions/DialogParameters.cs
@@ -1,0 +1,91 @@
+using System.Collections;
+
+namespace Flare.Abstractions;
+
+/// <summary>
+/// A bag of values bound to the parameters of a component rendered as a dialog body. Keys are the
+/// target component's <c>[Parameter]</c> property names; values are the arguments bound to them.
+/// </summary>
+/// <remarks>
+/// Build one fluently and pass it to <see cref="IDialogService.ShowAsync{TComponent}"/>:
+/// <code>
+/// var parameters = new DialogParameters()
+///     .Add(nameof(MyDialog.Title), "Edit profile")
+///     .Add(nameof(MyDialog.Model), model);
+/// </code>
+/// </remarks>
+public sealed class DialogParameters : IEnumerable<KeyValuePair<string, object?>>
+{
+    private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+
+    /// <summary>Creates an empty parameter bag.</summary>
+    public DialogParameters() { }
+
+    /// <summary>Creates a parameter bag pre-populated from the given name/value pairs.</summary>
+    /// <param name="values">The initial parameter name/value pairs.</param>
+    public DialogParameters(IEnumerable<KeyValuePair<string, object?>> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        foreach (var pair in values)
+            _values[pair.Key] = pair.Value;
+    }
+
+    /// <summary>Gets or sets the value bound to the component parameter named <paramref name="name"/>.</summary>
+    /// <param name="name">The target component parameter name.</param>
+    public object? this[string name]
+    {
+        get => _values.TryGetValue(name, out var value) ? value : null;
+        set => _values[name] = value;
+    }
+
+    /// <summary>The number of parameters in the bag.</summary>
+    public int Count => _values.Count;
+
+    /// <summary>Adds or replaces the value bound to the component parameter <paramref name="name"/>.</summary>
+    /// <param name="name">The target component parameter name.</param>
+    /// <param name="value">The value to bind, or null.</param>
+    /// <returns>The same bag, so calls can be chained.</returns>
+    public DialogParameters Add(string name, object? value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        _values[name] = value;
+        return this;
+    }
+
+    /// <summary>Adds or replaces a strongly-typed value bound to the component parameter <paramref name="name"/>.</summary>
+    /// <typeparam name="T">The value type, matching the target parameter's type.</typeparam>
+    /// <param name="name">The target component parameter name.</param>
+    /// <param name="value">The value to bind.</param>
+    /// <returns>The same bag, so calls can be chained.</returns>
+    public DialogParameters Add<T>(string name, T value) => Add(name, (object?)value);
+
+    /// <summary>Removes the parameter <paramref name="name"/>.</summary>
+    /// <param name="name">The parameter name to remove.</param>
+    /// <returns><see langword="true"/> when the parameter was present and removed.</returns>
+    public bool Remove(string name) => _values.Remove(name);
+
+    /// <summary>Determines whether the bag contains a parameter named <paramref name="name"/>.</summary>
+    /// <param name="name">The parameter name to look for.</param>
+    public bool Contains(string name) => _values.ContainsKey(name);
+
+    /// <summary>Tries to get the value bound to <paramref name="name"/>.</summary>
+    /// <param name="name">The parameter name to look up.</param>
+    /// <param name="value">The bound value when present, otherwise null.</param>
+    /// <returns><see langword="true"/> when the parameter was present.</returns>
+    public bool TryGetValue(string name, out object? value) => _values.TryGetValue(name, out value);
+
+    // Snapshot in the shape DynamicComponent.Parameters requires (IDictionary&lt;string, object&gt;).
+    // Internal: consumed only by the dialog provider host, not part of the public surface.
+    internal Dictionary<string, object> ToComponentParameters()
+    {
+        var snapshot = new Dictionary<string, object>(_values.Count, StringComparer.Ordinal);
+        foreach (var pair in _values)
+            snapshot[pair.Key] = pair.Value!;
+        return snapshot;
+    }
+
+    /// <summary>Returns an enumerator over the parameter name/value pairs.</summary>
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => _values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Flare.Abstractions/Abstractions/DialogReference.cs
+++ b/src/Flare.Abstractions/Abstractions/DialogReference.cs
@@ -1,0 +1,28 @@
+namespace Flare.Abstractions;
+
+/// <summary>
+/// A handle to an open component dialog returned by <see cref="IDialogService.Show{TComponent}"/>.
+/// Await <see cref="Result"/> for its outcome, or close it programmatically from the caller side.
+/// </summary>
+public sealed class DialogReference
+{
+    private readonly FlareDialogInstance _instance;
+
+    internal DialogReference(FlareDialogInstance instance) => _instance = instance;
+
+    /// <summary>The dialog's unique id.</summary>
+    public Guid Id => _instance.Id;
+
+    /// <summary>The live instance handle (also cascaded to the dialog body).</summary>
+    public FlareDialogInstance Instance => _instance;
+
+    /// <summary>Completes when the dialog closes, with the user's <see cref="DialogResult"/>.</summary>
+    public Task<DialogResult> Result => _instance.ResultTask;
+
+    /// <summary>Programmatically closes the dialog with the given result.</summary>
+    /// <param name="result">The outcome to resolve the dialog with.</param>
+    public void Close(DialogResult result) => _instance.Close(result);
+
+    /// <summary>Programmatically cancels (dismisses) the dialog.</summary>
+    public void Cancel() => _instance.Cancel();
+}

--- a/src/Flare.Abstractions/Abstractions/DialogResult.cs
+++ b/src/Flare.Abstractions/Abstractions/DialogResult.cs
@@ -1,0 +1,42 @@
+namespace Flare.Abstractions;
+
+/// <summary>
+/// The outcome of a component dialog: either a cancellation, or a confirmation that may carry a
+/// payload returned by the dialog body. Construct via <see cref="Ok(object?)"/> / <see cref="Cancel"/>.
+/// </summary>
+public sealed class DialogResult
+{
+    private DialogResult(bool cancelled, object? data)
+    {
+        Cancelled = cancelled;
+        Data = data;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> when the dialog was dismissed or cancelled rather than confirmed
+    /// (for example via the cancel button, the scrim, or the Escape key).
+    /// </summary>
+    public bool Cancelled { get; }
+
+    /// <summary>The payload returned by the dialog body, or null. Only meaningful when not <see cref="Cancelled"/>.</summary>
+    public object? Data { get; }
+
+    /// <summary>A confirmed result carrying an optional payload.</summary>
+    /// <param name="data">The value to return to the caller, or null.</param>
+    public static DialogResult Ok(object? data = null) => new(cancelled: false, data);
+
+    /// <summary>A confirmed result carrying a strongly-typed payload.</summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="data">The value to return to the caller.</param>
+    public static DialogResult Ok<T>(T data) => new(cancelled: false, data);
+
+    /// <summary>A cancelled (dismissed) result with no payload.</summary>
+    public static DialogResult Cancel() => new(cancelled: true, data: null);
+
+    /// <summary>
+    /// Gets the payload cast to <typeparamref name="T"/>, or <see langword="default"/> when the
+    /// dialog was cancelled or the payload is absent or of a different type.
+    /// </summary>
+    /// <typeparam name="T">The expected payload type.</typeparam>
+    public T? GetData<T>() => Data is T value ? value : default;
+}

--- a/src/Flare.Abstractions/Abstractions/DialogSize.cs
+++ b/src/Flare.Abstractions/Abstractions/DialogSize.cs
@@ -1,6 +1,6 @@
-namespace Flare.Components;
+namespace Flare.Abstractions;
 
-/// <summary>Maximum-width size presets for <see cref="FlareDialog"/>.</summary>
+/// <summary>Maximum-width size presets for a Flare dialog (<c>FlareDialog</c> / a component dialog).</summary>
 public enum DialogSize
 {
     /// <summary>Extra-small dialog (max 20 rem).</summary>

--- a/src/Flare.Abstractions/Abstractions/FlareDialogInstance.cs
+++ b/src/Flare.Abstractions/Abstractions/FlareDialogInstance.cs
@@ -1,0 +1,84 @@
+namespace Flare.Abstractions;
+
+/// <summary>
+/// The runtime handle for one open component dialog. The dialog provider cascades it to the dialog
+/// body as a <c>[CascadingParameter]</c>, so the body can close itself and return a result:
+/// <code>
+/// [CascadingParameter] public FlareDialogInstance Dialog { get; set; } = default!;
+/// // ...
+/// Dialog.Close(editedModel); // confirm with a payload
+/// Dialog.Cancel();           // dismiss
+/// </code>
+/// </summary>
+public sealed class FlareDialogInstance
+{
+    private readonly TaskCompletionSource<DialogResult> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Action<FlareDialogInstance> _onClose;
+    private Dictionary<string, object>? _componentParameters;
+    private int _closed;
+
+    internal FlareDialogInstance(
+        Guid id,
+        Type contentType,
+        string? title,
+        DialogParameters parameters,
+        DialogOptions options,
+        Action<FlareDialogInstance> onClose)
+    {
+        Id = id;
+        ContentType = contentType;
+        Title = title;
+        Parameters = parameters;
+        Options = options;
+        _onClose = onClose;
+    }
+
+    /// <summary>The unique id of this open dialog.</summary>
+    public Guid Id { get; }
+
+    /// <summary>The component type rendered as the dialog body.</summary>
+    public Type ContentType { get; }
+
+    /// <summary>The dialog title shown in the header, or null for a header-less dialog.</summary>
+    public string? Title { get; }
+
+    /// <summary>The parameters bound to the body component.</summary>
+    public DialogParameters Parameters { get; }
+
+    /// <summary>The presentation options applied to this dialog.</summary>
+    public DialogOptions Options { get; }
+
+    /// <summary>Whether the dialog has already been closed (its result is settled).</summary>
+    public bool IsClosed => _closed != 0;
+
+    // The awaitable surfaced through DialogReference.Result.
+    internal Task<DialogResult> ResultTask => _completion.Task;
+
+    // Cached parameter snapshot for DynamicComponent; built once since parameters are fixed per show.
+    internal Dictionary<string, object> ComponentParameters =>
+        _componentParameters ??= Parameters.ToComponentParameters();
+
+    /// <summary>Closes the dialog, resolving the awaiting caller with <paramref name="result"/>.</summary>
+    /// <param name="result">The outcome to return to the caller.</param>
+    public void Close(DialogResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        // First close wins; later Close/Cancel calls (e.g. a queued scrim click) are ignored.
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+            return;
+        _completion.TrySetResult(result);
+        _onClose(this);
+    }
+
+    /// <summary>Closes the dialog with a confirmed result that carries no payload.</summary>
+    public void Close() => Close(DialogResult.Ok());
+
+    /// <summary>Closes the dialog with a confirmed, strongly-typed payload.</summary>
+    /// <typeparam name="T">The payload type.</typeparam>
+    /// <param name="returnValue">The value to return to the caller.</param>
+    public void Close<T>(T returnValue) => Close(DialogResult.Ok(returnValue));
+
+    /// <summary>Cancels the dialog, resolving the awaiting caller with a cancelled result.</summary>
+    public void Cancel() => Close(DialogResult.Cancel());
+}

--- a/src/Flare.Abstractions/Abstractions/IDialogService.cs
+++ b/src/Flare.Abstractions/Abstractions/IDialogService.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Components;
+
 namespace Flare.Abstractions;
 
 /// <summary>An immutable description of a pending confirm/alert dialog request.</summary>
@@ -27,11 +29,48 @@ public interface IDialogService
     /// <summary>Shows an alert dialog with a single close button. Returns when dismissed.</summary>
     Task AlertAsync(string title, string message, string closeLabel = "Close");
 
+    /// <summary>
+    /// Opens <typeparamref name="TComponent"/> as a modal dialog body and awaits its result. The
+    /// component receives the supplied <paramref name="parameters"/> and a cascaded
+    /// <see cref="FlareDialogInstance"/> it uses to close itself (<c>Dialog.Close(value)</c> /
+    /// <c>Dialog.Cancel()</c>). A dismissed dialog (scrim/Escape) resolves as
+    /// <see cref="DialogResult.Cancel"/>.
+    /// </summary>
+    /// <typeparam name="TComponent">The Blazor component rendered as the dialog body.</typeparam>
+    /// <param name="title">The dialog title, or null for a header-less dialog.</param>
+    /// <param name="parameters">Values bound to the body component's parameters, or null for none.</param>
+    /// <param name="options">Presentation options, or null for <see cref="DialogOptions.Default"/>.</param>
+    /// <returns>The <see cref="DialogResult"/> produced when the dialog closes.</returns>
+    Task<DialogResult> ShowAsync<TComponent>(string? title = null,
+        DialogParameters? parameters = null, DialogOptions? options = null)
+        where TComponent : IComponent;
+
+    /// <summary>
+    /// Opens <typeparamref name="TComponent"/> as a modal dialog body and returns a
+    /// <see cref="DialogReference"/> whose <see cref="DialogReference.Result"/> can be awaited and
+    /// which can also close the dialog from the caller side. Use this overload when you need the
+    /// handle (e.g. to close the dialog in response to an external event);
+    /// otherwise prefer <see cref="ShowAsync{TComponent}"/>.
+    /// </summary>
+    /// <typeparam name="TComponent">The Blazor component rendered as the dialog body.</typeparam>
+    /// <param name="title">The dialog title, or null for a header-less dialog.</param>
+    /// <param name="parameters">Values bound to the body component's parameters, or null for none.</param>
+    /// <param name="options">Presentation options, or null for <see cref="DialogOptions.Default"/>.</param>
+    /// <returns>A handle to the opened dialog.</returns>
+    DialogReference Show<TComponent>(string? title = null,
+        DialogParameters? parameters = null, DialogOptions? options = null)
+        where TComponent : IComponent;
+
     // Provider communication
     /// <summary>Raised when the pending request changes, so the host component can re-render.</summary>
     event Action? OnStateChanged;
     /// <summary>The request currently awaiting a response, or null when no dialog is open.</summary>
     DialogRequest? Current { get; }
+    /// <summary>
+    /// The component dialogs currently open, in display order. The dialog provider host renders these
+    /// (it is not part of the typical app-facing API).
+    /// </summary>
+    IReadOnlyList<FlareDialogInstance> OpenDialogs { get; }
     /// <summary>Completes the pending request: true=confirmed, false=cancelled, null=dismissed.</summary>
     /// <param name="confirmed">The user's choice, or null when dismissed.</param>
     void Respond(bool? confirmed);

--- a/src/Flare.Abstractions/Flare.Abstractions.csproj
+++ b/src/Flare.Abstractions/Flare.Abstractions.csproj
@@ -22,9 +22,12 @@
 
   <ItemGroup>
     <!-- Pure security utilities (HtmlSanitizer/CssValidator) stay internal; the presentation and
-         theming layers consume them directly without widening the public API surface. -->
+         theming layers consume them directly without widening the public API surface.
+         Flare.Infrastructure builds the component-dialog handles (internal ctors on
+         FlareDialogInstance / DialogReference) when implementing IDialogService. -->
     <InternalsVisibleTo Include="Flare.Components" />
     <InternalsVisibleTo Include="Flare.Theming" />
+    <InternalsVisibleTo Include="Flare.Infrastructure" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Flare.Components/Dialog/FlareDialogProvider.razor
+++ b/src/Flare.Components/Dialog/FlareDialogProvider.razor
@@ -2,6 +2,7 @@
 @inherits FlareComponentBase
 @inject IDialogService DialogService
 
+@* Imperative confirm/alert request (the ConfirmAsync / AlertAsync path). *@
 @if (DialogService.Current is not null)
 {
     var req = DialogService.Current;
@@ -26,6 +27,27 @@
     </FlareDialog>
 }
 
+@* Component dialogs opened via ShowAsync<TComponent> / Show<TComponent>: the body component is
+   hosted dynamically and receives the FlareDialogInstance as a cascading value so it can close
+   itself with a typed result. *@
+@foreach (var dialog in DialogService.OpenDialogs)
+{
+    <FlareDialog @key="dialog.Id"
+                 Visible="true"
+                 Title="@dialog.Title"
+                 Size="dialog.Options.Size"
+                 Divider="dialog.Options.Divider"
+                 CloseOnScrimClick="dialog.Options.CloseOnScrimClick"
+                 CloseOnEsc="dialog.Options.CloseOnEsc"
+                 VisibleChanged="@(visible => HandleDialogVisibleChanged(dialog, visible))">
+        <ChildContent>
+            <CascadingValue Value="dialog" IsFixed="true">
+                <DynamicComponent Type="dialog.ContentType" Parameters="dialog.ComponentParameters" />
+            </CascadingValue>
+        </ChildContent>
+    </FlareDialog>
+}
+
 @code {
     protected override string ComponentCssClass => string.Empty;
 
@@ -36,6 +58,14 @@
     }
 
     private void HandleStateChanged() => InvokeAsync(StateHasChanged);
+
+    // FlareDialog raises VisibleChanged(false) on a scrim click or Escape (when enabled by options);
+    // treat that dismissal as a cancellation of the component dialog.
+    private void HandleDialogVisibleChanged(FlareDialogInstance dialog, bool visible)
+    {
+        if (!visible)
+            dialog.Cancel();
+    }
 
     public override async ValueTask DisposeAsync()
     {

--- a/src/Flare.Infrastructure/Feedback/DialogService.cs
+++ b/src/Flare.Infrastructure/Feedback/DialogService.cs
@@ -1,4 +1,5 @@
 using Flare.Abstractions;
+using Microsoft.AspNetCore.Components;
 
 namespace Flare.Infrastructure;
 
@@ -6,9 +7,12 @@ namespace Flare.Infrastructure;
 public sealed class DialogService : IDialogService
 {
     private TaskCompletionSource<bool?>? _tcs;
+    private readonly List<FlareDialogInstance> _openDialogs = [];
 
     /// <summary>The request currently awaiting a response, or null when no dialog is open.</summary>
     public DialogRequest? Current { get; private set; }
+    /// <summary>The component dialogs currently open, in display order.</summary>
+    public IReadOnlyList<FlareDialogInstance> OpenDialogs => _openDialogs;
     /// <summary>Raised when the pending request changes so the host can re-render.</summary>
     public event Action? OnStateChanged;
 
@@ -28,6 +32,40 @@ public sealed class DialogService : IDialogService
     /// <summary>Shows an alert dialog with a single close button.</summary>
     public async Task AlertAsync(string title, string message, string closeLabel = "Close")
         => await Show(new(title, message, closeLabel, string.Empty, ShowCancel: false));
+
+    /// <summary>Opens a component dialog and awaits its result.</summary>
+    public Task<DialogResult> ShowAsync<TComponent>(string? title = null,
+        DialogParameters? parameters = null, DialogOptions? options = null)
+        where TComponent : IComponent
+    {
+        // Note: DialogReference.Result is the awaitable Task, not a blocking Task.Result.
+        DialogReference reference = Show<TComponent>(title, parameters, options);
+        return reference.Result;
+    }
+
+    /// <summary>Opens a component dialog and returns a handle whose result can be awaited.</summary>
+    public DialogReference Show<TComponent>(string? title = null,
+        DialogParameters? parameters = null, DialogOptions? options = null)
+        where TComponent : IComponent
+    {
+        var instance = new FlareDialogInstance(
+            Guid.NewGuid(),
+            typeof(TComponent),
+            title,
+            parameters ?? new DialogParameters(),
+            options ?? new DialogOptions(),
+            Remove);
+        _openDialogs.Add(instance);
+        OnStateChanged?.Invoke();
+        return new DialogReference(instance);
+    }
+
+    // Called by a FlareDialogInstance when it closes (button, scrim, Escape, or programmatic close).
+    private void Remove(FlareDialogInstance instance)
+    {
+        if (_openDialogs.Remove(instance))
+            OnStateChanged?.Invoke();
+    }
 
     /// <summary>Completes the pending request with the user's choice.</summary>
     public void Respond(bool? confirmed)

--- a/tests/Flare.Components.Tests/Component/ComponentDialogTests.cs
+++ b/tests/Flare.Components.Tests/Component/ComponentDialogTests.cs
@@ -1,0 +1,258 @@
+using Flare.Abstractions;
+using Flare.Infrastructure;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Flare.Components.Tests.Component;
+
+// A minimal dialog body used by the component-dialog tests: it reads a [Parameter] payload and
+// closes itself through the cascaded FlareDialogInstance (the same contract a real dialog body uses).
+internal sealed class TestDialogBody : ComponentBase
+{
+    [CascadingParameter] public FlareDialogInstance Dialog { get; set; } = default!;
+    [Parameter] public string Payload { get; set; } = "";
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "button");
+        builder.AddAttribute(1, "class", "test-ok");
+        builder.AddAttribute(2, "onclick", EventCallback.Factory.Create(this, () => Dialog.Close(Payload)));
+        builder.AddContent(3, "OK");
+        builder.CloseElement();
+
+        builder.OpenElement(4, "button");
+        builder.AddAttribute(5, "class", "test-cancel");
+        builder.AddAttribute(6, "onclick", EventCallback.Factory.Create(this, () => Dialog.Cancel()));
+        builder.AddContent(7, "Cancel");
+        builder.CloseElement();
+    }
+}
+
+// ------------------------------------------------------------------------------
+// DialogResult / DialogParameters  (pure unit tests)
+// ------------------------------------------------------------------------------
+
+public class C_DialogResultTests
+{
+    [Fact]
+    public void Ok_IsNotCancelled_AndCarriesPayload()
+    {
+        var result = DialogResult.Ok(123);
+
+        Assert.False(result.Cancelled);
+        Assert.Equal(123, result.GetData<int>());
+    }
+
+    [Fact]
+    public void Cancel_IsCancelled_WithNoData()
+    {
+        var result = DialogResult.Cancel();
+
+        Assert.True(result.Cancelled);
+        Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public void GetData_WrongType_ReturnsDefault()
+    {
+        var result = DialogResult.Ok("text");
+
+        Assert.Equal(0, result.GetData<int>());
+        Assert.Null(result.GetData<string[]>());
+    }
+}
+
+public class C_DialogParametersTests
+{
+    [Fact]
+    public void AddAndIndexer_RoundTripValues()
+    {
+        var parameters = new DialogParameters()
+            .Add("A", 1)
+            .Add("B", "x");
+        parameters["C"] = true;
+
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal(1, parameters["A"]);
+        Assert.True(parameters.Contains("B"));
+        Assert.True((bool)parameters["C"]!);
+    }
+
+    [Fact]
+    public void Remove_DropsParameter()
+    {
+        var parameters = new DialogParameters().Add("A", 1);
+
+        Assert.True(parameters.Remove("A"));
+        Assert.False(parameters.Contains("A"));
+        Assert.Equal(0, parameters.Count);
+    }
+
+    [Fact]
+    public void MissingKey_IndexerReturnsNull()
+    {
+        var parameters = new DialogParameters();
+
+        Assert.Null(parameters["nope"]);
+        Assert.False(parameters.TryGetValue("nope", out _));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// DialogService component-dialog API  (service-level, no rendering)
+// ------------------------------------------------------------------------------
+
+public class C_DialogServiceComponentTests
+{
+    [Fact]
+    public void Show_AddsToOpenDialogs_AndRaisesStateChanged()
+    {
+        var service = new DialogService();
+        var stateChanges = 0;
+        service.OnStateChanged += () => stateChanges++;
+
+        var reference = service.Show<TestDialogBody>("Edit",
+            new DialogParameters().Add(nameof(TestDialogBody.Payload), "x"),
+            new DialogOptions { Size = DialogSize.Sm });
+
+        Assert.Single(service.OpenDialogs);
+        Assert.Equal("Edit", service.OpenDialogs[0].Title);
+        Assert.Equal(DialogSize.Sm, service.OpenDialogs[0].Options.Size);
+        Assert.Equal(typeof(TestDialogBody), service.OpenDialogs[0].ContentType);
+        Assert.False(reference.Result.IsCompleted);
+        Assert.Equal(1, stateChanges);
+    }
+
+    [Fact]
+    public async Task ClosingInstance_ResolvesResultWithPayload_AndRemovesDialog()
+    {
+        var service = new DialogService();
+        var stateChanges = 0;
+        service.OnStateChanged += () => stateChanges++;
+
+        var reference = service.Show<TestDialogBody>("Edit");
+        reference.Instance.Close("payload-42");
+
+        var result = await reference.Result;
+        Assert.False(result.Cancelled);
+        Assert.Equal("payload-42", result.GetData<string>());
+        Assert.Empty(service.OpenDialogs);
+        Assert.Equal(2, stateChanges); // one for show, one for close
+    }
+
+    [Fact]
+    public async Task Cancel_ResolvesCancelled_AndRemovesDialog()
+    {
+        var service = new DialogService();
+
+        var reference = service.Show<TestDialogBody>("Edit");
+        reference.Cancel();
+
+        var result = await reference.Result;
+        Assert.True(result.Cancelled);
+        Assert.Null(result.Data);
+        Assert.Empty(service.OpenDialogs);
+    }
+
+    [Fact]
+    public async Task SecondClose_IsIgnored_FirstResultWins()
+    {
+        var service = new DialogService();
+
+        var reference = service.Show<TestDialogBody>("Edit");
+        reference.Instance.Close("first");
+        reference.Instance.Cancel(); // should be a no-op
+
+        var result = await reference.Result;
+        Assert.False(result.Cancelled);
+        Assert.Equal("first", result.GetData<string>());
+        Assert.True(reference.Instance.IsClosed);
+    }
+
+    [Fact]
+    public async Task ShowAsync_ReturnsAwaitableResult()
+    {
+        var service = new DialogService();
+
+        var task = service.ShowAsync<TestDialogBody>("Edit");
+        Assert.False(task.IsCompleted);
+
+        service.OpenDialogs[0].Close("done");
+
+        var result = await task;
+        Assert.Equal("done", result.GetData<string>());
+    }
+
+    [Fact]
+    public void Show_MultipleDialogs_StackInOrder()
+    {
+        var service = new DialogService();
+
+        var first = service.Show<TestDialogBody>("First");
+        var second = service.Show<TestDialogBody>("Second");
+
+        Assert.Equal(2, service.OpenDialogs.Count);
+        Assert.Equal("First", service.OpenDialogs[0].Title);
+        Assert.Equal("Second", service.OpenDialogs[1].Title);
+
+        first.Cancel();
+        Assert.Single(service.OpenDialogs);
+        Assert.Equal("Second", service.OpenDialogs[0].Title);
+        second.Cancel();
+        Assert.Empty(service.OpenDialogs);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareDialogProvider rendering of component dialogs  (bUnit)
+// ------------------------------------------------------------------------------
+
+public class C_FlareDialogProviderComponentTests : FlareTestContext
+{
+    public C_FlareDialogProviderComponentTests()
+    {
+        Services.AddSingleton<IDialogService, DialogService>();
+    }
+
+    [Fact]
+    public void NoComponentDialog_NoScrim()
+    {
+        var cut = Render<FlareDialogProvider>();
+
+        Assert.Empty(cut.FindAll(".flare-dialog-scrim"));
+    }
+
+    [Fact]
+    public void Show_RendersBodyAndTitle()
+    {
+        var service = Services.GetRequiredService<IDialogService>();
+        var cut = Render<FlareDialogProvider>();
+
+        service.Show<TestDialogBody>("Edit profile",
+            new DialogParameters().Add(nameof(TestDialogBody.Payload), "hello"));
+        cut.WaitForState(() => cut.FindAll(".flare-dialog-scrim").Count > 0);
+
+        Assert.NotEmpty(cut.FindAll(".test-ok"));
+        Assert.Contains("Edit profile", cut.Find(".flare-dialog__title").TextContent);
+    }
+
+    [Fact]
+    public async Task ClickingBodyButton_ClosesDialog_AndResolvesResult()
+    {
+        var service = Services.GetRequiredService<IDialogService>();
+        var cut = Render<FlareDialogProvider>();
+
+        var reference = service.Show<TestDialogBody>("Edit",
+            new DialogParameters().Add(nameof(TestDialogBody.Payload), "hello"));
+        cut.WaitForState(() => cut.FindAll(".test-ok").Count > 0);
+
+        cut.Find(".test-ok").Click();
+        cut.WaitForState(() => cut.FindAll(".flare-dialog-scrim").Count == 0);
+
+        var result = await reference.Result;
+        Assert.False(result.Cancelled);
+        Assert.Equal("hello", result.GetData<string>());
+        Assert.Empty(service.OpenDialogs);
+    }
+}


### PR DESCRIPTION
Add a generic, reusable component-dialog API so any Blazor component can be rendered as a modal and return a typed result, replacing inline @bind-Visible workarounds.

- IDialogService.ShowAsync<TComponent>(title, parameters, options) -> Task<DialogResult> and Show<TComponent>(...) -> DialogReference (awaitable Result + caller-side close).
- DialogParameters (fluent name->value bag), DialogResult (Ok/Cancel + typed GetData<T>), DialogOptions (Size/CloseOnScrimClick/CloseOnEsc/Divider), DialogReference.
- FlareDialogInstance cascaded to the body component (Close/Cancel); rendered through FlareDialogProvider via DynamicComponent, reusing FlareDialog visuals/scrim/focus-trap/Esc.
- Existing ConfirmAsync/AlertAsync unchanged.
- DialogSize moved from Flare.Components to Flare.Abstractions (shared dialog contract).
- Gallery: new Component dialog demo on the Dialog page, plus a new Dialog service page under Services (/services/dialog); EN/RU strings for both.
- Docs: getting-started (en/ru) now shows ShowAsync<TComponent> + FlareDialogInstance.
- Tests: 15 new tests (DialogResult/DialogParameters/service/provider render).
- Changelog + version bump to 0.0.7.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
