### PR TITLE
Feat: close component API gaps from the PlaylistShared migration (0.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to Flare are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.0.8] - 2026-07-01
+
+Migrating a real application (PlaylistShared) from MudBlazor to Flare surfaced a batch of small,
+generally-useful API gaps in existing components. This release closes them. Every addition is purely
+additive and backward-compatible.
+
+### Added
+- **`FlareIconButton`** - a dedicated icon-only button. A thin wrapper over `FlareButton` that renders
+  an `Icon` (or custom `ChildContent`) as the button's leading icon with no label, so the square
+  icon-only treatment applies automatically. Replaces the verbose
+  `<FlareButton><LeadingIcon><FlareIcon/></LeadingIcon></FlareButton>` idiom. Defaults to the
+  `Text` ("standard") variant and forwards `Variant`/`Size`/`Color`/`Shape`/`Disabled`/`Loading`/
+  `Href`/`Target`/`AriaLabel`/`OnClick`.
+- **`FlareCollapse`** - a standalone expand/collapse container for a single region (unlike
+  `FlareAccordion`, which is a panel group). Driven by `@bind-Expanded`, or by an optional built-in
+  toggle `Header` / `HeaderContent`. The region animates its height open/closed. New
+  `flare-collapse*` classes and a Gallery page.
+- **`FlareChip.Variant`** (new `ChipVariant`: `Outlined` (default) / `Filled` / `Elevated`). The
+  existing `Elevated` boolean is now shorthand for `Variant="ChipVariant.Elevated"`. New
+  `flare-chip--filled` / `flare-chip--outlined` classes.
+- **`FlareAvatar.FallbackIcon`** (Material Symbols name, default `person`) and **`FallbackContent`**
+  (`RenderFragment`) for the no-image/no-text case, replacing the previously hard-coded icon.
+- **`FlareField.Error` / `FlareField.Invalid`** - force the invalid visual state (and `aria-invalid`)
+  without requiring an `ErrorText` message. Inherited by `FlareTextField`.
+- **`FlareField.FullWidth`** (default `true`; `false` sizes the field to its content) and
+  **`FlareField.Margin`** (new `FieldMargin`: `None` / `Dense` / `Normal`), inherited by `FlareTextField`.
+- **`FlareStack.StretchItems`** (every child shares the main axis equally) and **`StretchFirst`**
+  (only the first child grows to fill the remaining space).
+- **`FlareMenuItem.Target`** (for an external `Href`; `_blank` adds `rel="noopener noreferrer"`) and
+  **`IconColor` / `LeadingIconColor`** to tint the leading icon.
+- **`FlareToggleGroup.Size` / `Color` / `Disabled`** cascade to every child `FlareToggleButton`
+  (set once on the group). `FlareToggleButton` gains a `Color` parameter that tints its selected state.
+- **`FlareCard.Elevation`** (nullable `int`, 0-5 on the MD3 elevation scale, clamped) overrides the
+  variant's shadow; `Elevation="0"` is flat.
+- **`FlareSelect` declarative options** - populate a select with native
+  `<option value="..">Label</option>` child markup as an alternative to the `Items` collection.
+- **`ISnackbarService.Show(string, SnackbarOptions)`** - an options overload carrying per-message
+  severity/timing/action plus a per-message `CssClass` and a `CloseAfterNavigation` flag (the snackbar
+  is dismissed automatically on the next route change). New `SnackbarOptions` type; `SnackbarMessage`
+  gains `CssClass` and `CloseAfterNavigation`.
+- **`FlareLink.Typo`** - apply a `TypographyScale` to the link text (otherwise it inherits the
+  surrounding typography).
+- Gallery: new demos for each of the above (Chip variants, Avatar fallback, Card elevation, Stack
+  stretch, Menu icon color & external links, Toggle group cascade, Field error state, Field width &
+  margin, Link typography, Snackbar options, a "shown only in a band" `FlareHidden` example), a new
+  Collapse page, and the Icon Button demos rebuilt on `FlareIconButton`.
+
+### Notes
+- `FlareHidden` already supported showing an element only within a breakpoint band via
+  `Only` + `Invert`; this is now demonstrated on the Responsive page. `FlareSlider` already exposes a
+  `Vertical` parameter, so no separate vertical-bar component was added.
+
 ## [0.0.7] - 2026-06-30
 
 This release adds a **generic component-dialog service** - render any Blazor component as a modal and

--- a/samples/Flare.Gallery/Layout/MainLayout.razor
+++ b/samples/Flare.Gallery/Layout/MainLayout.razor
@@ -15,7 +15,7 @@
                     <FlareText Typo="TypographyScale.TitleLarge" Weight="FontWeight.ExtraBold" Style="letter-spacing:-0.5px;">Flare</FlareText>
                 </FlareStack>
             </FlareLink>
-            <FlareBadge Text="v0.0.7" Standalone="true" Color="FlareColor.Secondary" />
+            <FlareBadge Text="v0.0.8" Standalone="true" Color="FlareColor.Secondary" />
             <FlareSpacer />
             <GallerySearch />
             <FlareSpacer />

--- a/samples/Flare.Gallery/Models/ComponentCatalog.cs
+++ b/samples/Flare.Gallery/Models/ComponentCatalog.cs
@@ -124,6 +124,7 @@ public static class ComponentCatalog
         // -- Layout & Surfaces ----------------------------------------------------
         new ComponentEntry("/components/accordion",         "Accordion",               "Accordion_Title",       ComponentGroup.Layout),
         new ComponentEntry("/components/cards",             "Card",                    "Cards_Title",           ComponentGroup.Layout),
+        new ComponentEntry("/components/collapse",          "Collapse",                "Collapse_Title",        ComponentGroup.Layout),
         new ComponentEntry("/components/container",         "Container",               "Container_Title",       ComponentGroup.Layout),
         new ComponentEntry("/components/divider",           "Divider",                 "Divider_Title",         ComponentGroup.Layout),
         new ComponentEntry("/components/grid",              "Grid",                    "Grid_Title",            ComponentGroup.Layout),

--- a/samples/Flare.Gallery/Pages/Components/Avatar/AvatarPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Avatar/AvatarPage.razor
@@ -9,6 +9,7 @@
 </GalleryPageTitle>
 
 <AutoDemoSection Title="@GalleryStrings.Avatar_ImageFallback" DemoType="typeof(Examples.AvatarImageFallbackDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Avatar_Fallback" DemoType="typeof(Examples.AvatarFallbackDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Avatar_Variants" DemoType="typeof(Examples.AvatarShapesDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Avatar_Sizes" DemoType="typeof(Examples.AvatarSizesDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Avatar_Color" DemoType="typeof(Examples.AvatarColorDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Avatar/Examples/AvatarFallbackDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Avatar/Examples/AvatarFallbackDemo.razor
@@ -1,0 +1,10 @@
+@* No image and no text: the avatar shows a fallback. Default is "person"; FallbackIcon picks any
+   Material Symbol, and FallbackContent supplies fully custom content. *@
+<FlareStack Row Wrap Gap="FlareSpacing.Medium" Align="FlareAlignItems.Center">
+    <FlareAvatar Size="AvatarSize.Lg" />
+    <FlareAvatar Size="AvatarSize.Lg" FallbackIcon="group" Color="@Colors.Secondary" />
+    <FlareAvatar Size="AvatarSize.Lg" FallbackIcon="smart_toy" Color="@Colors.Tertiary" />
+    <FlareAvatar Size="AvatarSize.Lg" Color="@Colors.Primary">
+        <FallbackContent><FlareIcon Name="rocket_launch" /></FallbackContent>
+    </FlareAvatar>
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/Cards/CardsPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Cards/CardsPage.razor
@@ -11,6 +11,7 @@
 </GalleryPageTitle>
 
 <AutoDemoSection Title="@GalleryStrings.Cards_Variants" DemoType="typeof(Examples.CardsVariantsDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Cards_Elevation" DemoType="typeof(Examples.CardsElevationDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Cards_Sizes" DemoType="typeof(Examples.CardsSizesDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Cards_Compact" DemoType="typeof(Examples.CardsCompactDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Cards_Selectable" DemoType="typeof(Examples.CardsSelectableDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Cards/Examples/CardsElevationDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Cards/Examples/CardsElevationDemo.razor
@@ -1,0 +1,15 @@
+@* Numeric Elevation overrides the variant's shadow on the MD3 0-5 scale. Elevation="0" is flat. *@
+<div style="display:flex;flex-wrap:wrap;gap:1rem;">
+    @for (var level = 0; level <= 5; level++)
+    {
+        var n = level;
+        <FlareCard Elevation="n" Style="flex:0 0 8rem;">
+            <FlareCardContent>
+                <FlareText Typo="TypographyScale.TitleSmall">Elevation @n</FlareText>
+                <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodySmall">
+                    @(n == 0 ? "flat" : $"level {n}")
+                </FlareText>
+            </FlareCardContent>
+        </FlareCard>
+    }
+</div>

--- a/samples/Flare.Gallery/Pages/Components/Chip/ChipPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Chip/ChipPage.razor
@@ -9,5 +9,6 @@
 </GalleryPageTitle>
 
 <AutoDemoSection Title="@GalleryStrings.Chip_Basic" DemoType="typeof(Examples.ChipBasicDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Chip_Variants" DemoType="typeof(Examples.ChipVariantsDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Chip_IconAvatar" DemoType="typeof(Examples.ChipIconAvatarDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Chip_SizeColor" DemoType="typeof(Examples.ChipSizeColorDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Chip/Examples/ChipVariantsDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Chip/Examples/ChipVariantsDemo.razor
@@ -1,0 +1,7 @@
+<FlareStack Row Wrap Gap="FlareSpacing.Small" Align="FlareAlignItems.Center">
+    <FlareChip Label="Outlined" Variant="ChipVariant.Outlined" />
+    <FlareChip Label="Filled" Variant="ChipVariant.Filled" />
+    <FlareChip Label="Elevated" Variant="ChipVariant.Elevated" />
+    <FlareChip Label="Filled primary" Variant="ChipVariant.Filled" Color="@Colors.Primary" />
+    <FlareChip Label="Outlined error" Variant="ChipVariant.Outlined" Color="@Colors.Error" />
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/Collapse/CollapsePage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Collapse/CollapsePage.razor
@@ -1,0 +1,12 @@
+@page "/components/collapse"
+@inherits LocalizedPage
+
+<PageTitle>@GalleryStrings.Collapse_Title - Flare</PageTitle>
+
+<GalleryPageTitle Api="FlareCollapse">
+    <FlareText Typo="TypographyScale.HeadlineMedium">@GalleryStrings.Collapse_Title</FlareText>
+    <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodyLarge">@GalleryStrings.Collapse_Subtitle</FlareText>
+</GalleryPageTitle>
+
+<AutoDemoSection Title="@GalleryStrings.Collapse_Standalone" DemoType="typeof(Examples.CollapseStandaloneDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Collapse_Header" DemoType="typeof(Examples.CollapseHeaderDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Collapse/Examples/CollapseHeaderDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Collapse/Examples/CollapseHeaderDemo.razor
@@ -1,0 +1,24 @@
+@* With a Header, the collapse renders its own clickable toggle (a single-panel disclosure). *@
+<FlareStack Gap="FlareSpacing.Small" Style="max-width:32rem;">
+    <FlareCollapse Header="Shipping address">
+        <FlarePaper Style="padding:0.75rem 1rem;">
+            <FlareText Typo="TypographyScale.BodyMedium">221B Baker Street, London</FlareText>
+        </FlarePaper>
+    </FlareCollapse>
+
+    <FlareCollapse Expanded="true">
+        <HeaderContent>
+            <FlareIcon Name="info" />
+            <FlareText Typo="TypographyScale.TitleSmall">Rich header (starts open)</FlareText>
+        </HeaderContent>
+        <ChildContent>
+            <FlarePaper Style="padding:0.75rem 1rem;">
+                <FlareText Typo="TypographyScale.BodyMedium">HeaderContent accepts icons and custom markup.</FlareText>
+            </FlarePaper>
+        </ChildContent>
+    </FlareCollapse>
+
+    <FlareCollapse Header="Disabled (cannot toggle)" Disabled>
+        <FlarePaper Style="padding:0.75rem 1rem;">Hidden content</FlarePaper>
+    </FlareCollapse>
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/Collapse/Examples/CollapseStandaloneDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Collapse/Examples/CollapseStandaloneDemo.razor
@@ -1,0 +1,19 @@
+@* Headerless collapse: any external control drives the Expanded flag (@bind-Expanded). *@
+<FlareStack Gap="FlareSpacing.Medium" Align="FlareAlignItems.Start">
+    <FlareButton Variant="ButtonVariant.Tonal" OnClick="@(() => _open = !_open)">
+        @(_open ? "Hide details" : "Show details")
+    </FlareButton>
+
+    <FlareCollapse @bind-Expanded="_open">
+        <FlarePaper Elevation="1" Style="padding:1rem;max-width:28rem;">
+            <FlareText Typo="TypographyScale.BodyMedium">
+                This region expands and collapses with a smooth height animation. It is driven entirely
+                by the Expanded flag, so any button, switch or keyboard shortcut can control it.
+            </FlareText>
+        </FlarePaper>
+    </FlareCollapse>
+</FlareStack>
+
+@code {
+    private bool _open;
+}

--- a/samples/Flare.Gallery/Pages/Components/IconButton/Examples/IconButtonSizesDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IconButton/Examples/IconButtonSizesDemo.razor
@@ -1,19 +1,9 @@
 @using Flare.Gallery.Resources
 
 <FlareStack Row Align="FlareAlignItems.Center" Gap="FlareSpacing.Medium">
-    <FlareButton Size="ButtonSize.Xs" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.IconButton_AriaXSmall">
-        <LeadingIcon><FlareIcon Icon="delete" /></LeadingIcon>
-    </FlareButton>
-    <FlareButton Size="ButtonSize.Sm" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaSmall">
-        <LeadingIcon><FlareIcon Icon="delete" /></LeadingIcon>
-    </FlareButton>
-    <FlareButton Size="ButtonSize.Md" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaMedium">
-        <LeadingIcon><FlareIcon Icon="delete" /></LeadingIcon>
-    </FlareButton>
-    <FlareButton Size="ButtonSize.Lg" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaLarge">
-        <LeadingIcon><FlareIcon Icon="delete" /></LeadingIcon>
-    </FlareButton>
-    <FlareButton Size="ButtonSize.Xl" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.IconButton_AriaXLarge">
-        <LeadingIcon><FlareIcon Icon="delete" /></LeadingIcon>
-    </FlareButton>
+    <FlareIconButton Icon="delete" Size="ButtonSize.Xs" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.IconButton_AriaXSmall" />
+    <FlareIconButton Icon="delete" Size="ButtonSize.Sm" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaSmall" />
+    <FlareIconButton Icon="delete" Size="ButtonSize.Md" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaMedium" />
+    <FlareIconButton Icon="delete" Size="ButtonSize.Lg" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaLarge" />
+    <FlareIconButton Icon="delete" Size="ButtonSize.Xl" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.IconButton_AriaXLarge" />
 </FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/IconButton/Examples/IconButtonVariantsDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/IconButton/Examples/IconButtonVariantsDemo.razor
@@ -1,17 +1,7 @@
 @using Flare.Gallery.Resources
 
-<FlareButton Variant="ButtonVariant.Text" AriaLabel="@GalleryStrings.ButtonExtras_AriaSettings">
-    <LeadingIcon><FlareIcon>settings</FlareIcon></LeadingIcon>
-</FlareButton>
-<FlareButton Variant="ButtonVariant.Filled" AriaLabel="@GalleryStrings.ButtonExtras_AriaAdd">
-    <LeadingIcon><FlareIcon>add</FlareIcon></LeadingIcon>
-</FlareButton>
-<FlareButton Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaEdit">
-    <LeadingIcon><FlareIcon>edit</FlareIcon></LeadingIcon>
-</FlareButton>
-<FlareButton Variant="ButtonVariant.Outlined" AriaLabel="@GalleryStrings.ButtonExtras_AriaDelete">
-    <LeadingIcon><FlareIcon>delete</FlareIcon></LeadingIcon>
-</FlareButton>
-<FlareButton Variant="ButtonVariant.Text" Disabled AriaLabel="@GalleryStrings.ButtonExtras_AriaDisabled">
-    <LeadingIcon><FlareIcon>block</FlareIcon></LeadingIcon>
-</FlareButton>
+<FlareIconButton Icon="settings" Variant="ButtonVariant.Text" AriaLabel="@GalleryStrings.ButtonExtras_AriaSettings" />
+<FlareIconButton Icon="add" Variant="ButtonVariant.Filled" AriaLabel="@GalleryStrings.ButtonExtras_AriaAdd" />
+<FlareIconButton Icon="edit" Variant="ButtonVariant.Tonal" AriaLabel="@GalleryStrings.ButtonExtras_AriaEdit" />
+<FlareIconButton Icon="delete" Variant="ButtonVariant.Outlined" AriaLabel="@GalleryStrings.ButtonExtras_AriaDelete" />
+<FlareIconButton Icon="block" Variant="ButtonVariant.Text" Disabled AriaLabel="@GalleryStrings.ButtonExtras_AriaDisabled" />

--- a/samples/Flare.Gallery/Pages/Components/Link/Examples/LinkTypoDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Link/Examples/LinkTypoDemo.razor
@@ -1,0 +1,7 @@
+@* Typo applies a type-scale to the link text; without it the link inherits the surrounding typography. *@
+<FlareStack Gap="FlareSpacing.Small" Align="FlareAlignItems.Start">
+    <FlareLink Href="#" Typo="TypographyScale.HeadlineSmall">Headline link</FlareLink>
+    <FlareLink Href="#" Typo="TypographyScale.TitleMedium">Title link</FlareLink>
+    <FlareLink Href="#" Typo="TypographyScale.BodyMedium">Body link</FlareLink>
+    <FlareLink Href="#" Typo="TypographyScale.LabelSmall">Label link</FlareLink>
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/Link/LinkPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Link/LinkPage.razor
@@ -11,3 +11,4 @@
 <AutoDemoSection Title="@GalleryStrings.Link_Colors" DemoType="typeof(Examples.LinkColorsDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Link_Underline" DemoType="typeof(Examples.LinkUnderlineDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Link_States" DemoType="typeof(Examples.LinkStatesDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Link_Typo" DemoType="typeof(Examples.LinkTypoDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Menu/Examples/MenuIconColorDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Menu/Examples/MenuIconColorDemo.razor
@@ -1,0 +1,19 @@
+@* IconColor tints a menu item's leading icon; Target opens an external Href in a new tab. *@
+<FlareStack Row Gap="FlareSpacing.Large" Wrap Style="padding-bottom:8rem;">
+    <FlareMenu>
+        <Activator>
+            <FlareButton Variant="ButtonVariant.Outlined">
+                <LeadingIcon><FlareIcon Name="more_vert" /></LeadingIcon>
+                <ChildContent>Actions</ChildContent>
+            </FlareButton>
+        </Activator>
+        <ChildContent>
+            <FlareMenuItem Icon="edit" IconColor="@Colors.Primary">Edit</FlareMenuItem>
+            <FlareMenuItem Icon="content_copy" IconColor="@Colors.Secondary">Duplicate</FlareMenuItem>
+            <FlareMenuItem Icon="archive" IconColor="@Colors.Tertiary">Archive</FlareMenuItem>
+            <FlareMenuItem Icon="delete" IconColor="@Colors.Error">Delete</FlareMenuItem>
+            <FlareMenuItem Icon="open_in_new" IconColor="@Colors.Primary"
+                           Href="https://github.com/jrfrigat/Flare" Target="_blank">Open repository</FlareMenuItem>
+        </ChildContent>
+    </FlareMenu>
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/Menu/MenuPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Menu/MenuPage.razor
@@ -12,3 +12,4 @@
 <AutoDemoSection Title="Submenus" DemoType="typeof(Examples.MenuSubmenuDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Menu_Groups" DemoType="typeof(Examples.MenuGroupsDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Menu_Anchors" DemoType="typeof(Examples.MenuAnchorsDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Menu_IconColor" DemoType="typeof(Examples.MenuIconColorDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Responsive/ResponsivePage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Responsive/ResponsivePage.razor
@@ -38,6 +38,9 @@
     <FlareHidden Only="Breakpoint.Md">
         <FlareAlert Severity="AlertSeverity.Warning">@((MarkupString)GalleryStrings.Responsive_HiddenMd)</FlareAlert>
     </FlareHidden>
+    <FlareHidden Only="Breakpoint.Md" Invert>
+        <FlareAlert Severity="AlertSeverity.Info">@GalleryStrings.Responsive_ShownMd</FlareAlert>
+    </FlareHidden>
 </FlareStack>
 
 <FlareText Typo="TypographyScale.TitleMedium" Style="margin:2rem 0 0.5rem;">@GalleryStrings.Responsive_MediaQueryTitle</FlareText>

--- a/samples/Flare.Gallery/Pages/Components/Snackbar/Examples/SnackbarOptionsDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Snackbar/Examples/SnackbarOptionsDemo.razor
@@ -1,0 +1,24 @@
+@inject ISnackbarService Snackbar
+
+@* The options overload (SnackbarOptions) carries severity, a progress bar, per-message CssClass and
+   the CloseAfterNavigation flag in one bag. *@
+<FlareStack Row Wrap Gap="FlareSpacing.Small">
+    <FlareButton OnClick="ShowProgress">Severity + progress</FlareButton>
+    <FlareButton Variant="ButtonVariant.Tonal" OnClick="ShowCloseOnNav">Close after navigation</FlareButton>
+</FlareStack>
+
+@code {
+    private void ShowProgress() => Snackbar.Show("Uploading project files...", new SnackbarOptions
+    {
+        Severity = SnackbarSeverity.Info,
+        DurationMs = 6000,
+        ShowProgress = true,
+    });
+
+    private void ShowCloseOnNav() => Snackbar.Show("Dismissed when you navigate away", new SnackbarOptions
+    {
+        Severity = SnackbarSeverity.Warning,
+        DurationMs = 0,
+        CloseAfterNavigation = true,
+    });
+}

--- a/samples/Flare.Gallery/Pages/Components/Snackbar/SnackbarPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Snackbar/SnackbarPage.razor
@@ -10,3 +10,4 @@
 
 <AutoDemoSection Title="@GalleryStrings.Snackbar_Severity" DemoType="typeof(Examples.SnackbarSeverityDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Snackbar_Action" DemoType="typeof(Examples.SnackbarActionDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Snackbar_Options" DemoType="typeof(Examples.SnackbarOptionsDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/Stack/Examples/StackStretchDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/Stack/Examples/StackStretchDemo.razor
@@ -1,0 +1,13 @@
+@* StretchItems: every child shares the row equally. StretchFirst: only the first child grows. *@
+<FlareStack Gap="FlareSpacing.Large">
+    <FlareStack Row StretchItems Gap="FlareSpacing.Small">
+        <FlarePaper Elevation="1" Style="padding:0.75rem;text-align:center;">A</FlarePaper>
+        <FlarePaper Elevation="1" Style="padding:0.75rem;text-align:center;">B</FlarePaper>
+        <FlarePaper Elevation="1" Style="padding:0.75rem;text-align:center;">C</FlarePaper>
+    </FlareStack>
+
+    <FlareStack Row StretchFirst Gap="FlareSpacing.Small" Align="FlareAlignItems.Center">
+        <FlareTextField Placeholder="Grows to fill the row" />
+        <FlareButton Variant="ButtonVariant.Filled">Send</FlareButton>
+    </FlareStack>
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/Stack/StackPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/Stack/StackPage.razor
@@ -11,3 +11,4 @@
 <AutoDemoSection Title="@GalleryStrings.Layout_StackRow" DemoType="typeof(Examples.StackRowDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Layout_StackColumn" DemoType="typeof(Examples.StackColumnDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Layout_Spacer" DemoType="typeof(Examples.StackSpacerDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Layout_StackStretch" DemoType="typeof(Examples.StackStretchDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/TextField/Examples/TextFieldErrorDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/TextField/Examples/TextFieldErrorDemo.razor
@@ -1,0 +1,12 @@
+@* Error/Invalid forces the error visual state with no message. ErrorText shows the message too. *@
+<FlareStack Gap="FlareSpacing.Medium" Style="max-width:24rem;">
+    <FlareTextField Label="Invalid (state only)" Value="@("bad value")" Error />
+    <FlareTextField Label="With message" Value="@("bad value")" ErrorText="Value is not allowed" />
+    <FlareSwitch @bind-Value="_invalid" Label="Toggle error state" />
+    <FlareTextField Label="Bound to switch" @bind-Value="_text" Invalid="_invalid" />
+</FlareStack>
+
+@code {
+    private bool _invalid = true;
+    private string? _text = "Edit me";
+}

--- a/samples/Flare.Gallery/Pages/Components/TextField/Examples/TextFieldLayoutDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/TextField/Examples/TextFieldLayoutDemo.razor
@@ -1,0 +1,16 @@
+@* Fields are full-width (block) by default. FullWidth="false" sizes to content; Margin adds
+   vertical spacing (Dense / Normal). *@
+<FlareStack Gap="FlareSpacing.Large">
+    <div style="border:1px dashed var(--flare-color-outline-variant);padding:0.5rem;">
+        <FlareTextField Label="Full width (default)" Placeholder="Fills the container" />
+    </div>
+
+    <div style="border:1px dashed var(--flare-color-outline-variant);padding:0.5rem;">
+        <FlareTextField Label="Sized to content" Placeholder="FullWidth=false" FullWidth="false" />
+    </div>
+
+    <div style="border:1px dashed var(--flare-color-outline-variant);padding:0.5rem;">
+        <FlareTextField Label="Dense margin" Margin="FieldMargin.Dense" />
+        <FlareTextField Label="Dense margin" Margin="FieldMargin.Dense" />
+    </div>
+</FlareStack>

--- a/samples/Flare.Gallery/Pages/Components/TextField/TextFieldPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/TextField/TextFieldPage.razor
@@ -10,3 +10,5 @@
 
 <AutoDemoSection Title="@GalleryStrings.Input_Basic" DemoType="typeof(Examples.TextFieldDemo)" />
 <AutoDemoSection Title="@GalleryStrings.Field_Sizes" DemoType="typeof(Examples.TextFieldSizesDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Field_ErrorState" DemoType="typeof(Examples.TextFieldErrorDemo)" />
+<AutoDemoSection Title="@GalleryStrings.Field_FullWidthMargin" DemoType="typeof(Examples.TextFieldLayoutDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/ToggleButton/Examples/ToggleButtonGroupCascadeDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/ToggleButton/Examples/ToggleButtonGroupCascadeDemo.razor
@@ -1,0 +1,25 @@
+@* Size, Color and Disabled set once on the group cascade to every button inside it. *@
+<FlareStack Gap="FlareSpacing.Large" Align="FlareAlignItems.Start">
+    <FlareToggleGroup TValue="string" @bind-Value="_view" Size="ButtonSize.Lg" Color="@Colors.Tertiary">
+        <FlareToggleButton Value="@("list")" AriaLabel="List">
+            <OffIcon><FlareIcon Name="view_list" /></OffIcon>
+        </FlareToggleButton>
+        <FlareToggleButton Value="@("grid")" AriaLabel="Grid">
+            <OffIcon><FlareIcon Name="grid_view" /></OffIcon>
+        </FlareToggleButton>
+        <FlareToggleButton Value="@("board")" AriaLabel="Board">
+            <OffIcon><FlareIcon Name="view_kanban" /></OffIcon>
+        </FlareToggleButton>
+    </FlareToggleGroup>
+
+    <FlareToggleGroup TValue="string" Value="@("grid")" Disabled>
+        <FlareToggleButton Value="@("list")" AriaLabel="List"><OffIcon><FlareIcon Name="view_list" /></OffIcon></FlareToggleButton>
+        <FlareToggleButton Value="@("grid")" AriaLabel="Grid"><OffIcon><FlareIcon Name="grid_view" /></OffIcon></FlareToggleButton>
+    </FlareToggleGroup>
+
+    <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.LabelSmall">View: @_view</FlareText>
+</FlareStack>
+
+@code {
+    private string? _view = "list";
+}

--- a/samples/Flare.Gallery/Pages/Components/ToggleButton/ToggleButtonPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/ToggleButton/ToggleButtonPage.razor
@@ -13,3 +13,4 @@
 <AutoDemoSection Title="@GalleryStrings.ToggleButton_SizesDisabled" DemoType="typeof(Examples.ToggleButtonSizesDemo)" />
 <AutoDemoSection Title="@GalleryStrings.ToggleButton_Group" DemoType="typeof(Examples.ToggleButtonGroupDemo)" />
 <AutoDemoSection Title="@GalleryStrings.ToggleButton_GroupMulti" DemoType="typeof(Examples.ToggleButtonGroupMultiDemo)" />
+<AutoDemoSection Title="@GalleryStrings.ToggleButton_GroupCascade" DemoType="typeof(Examples.ToggleButtonGroupCascadeDemo)" />

--- a/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
@@ -8321,5 +8321,110 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("VirtualList_VirtualList", resourceCulture);
             }
         }
+
+        /// <summary>Looks up a localized string similar to Variants.</summary>
+        public static string Chip_Variants {
+            get {
+                return ResourceManager.GetString("Chip_Variants", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Fallback icon.</summary>
+        public static string Avatar_Fallback {
+            get {
+                return ResourceManager.GetString("Avatar_Fallback", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Error state (no message).</summary>
+        public static string Field_ErrorState {
+            get {
+                return ResourceManager.GetString("Field_ErrorState", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Width and margin.</summary>
+        public static string Field_FullWidthMargin {
+            get {
+                return ResourceManager.GetString("Field_FullWidthMargin", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Collapse.</summary>
+        public static string Collapse_Title {
+            get {
+                return ResourceManager.GetString("Collapse_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string for the Collapse page subtitle.</summary>
+        public static string Collapse_Subtitle {
+            get {
+                return ResourceManager.GetString("Collapse_Subtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Externally controlled.</summary>
+        public static string Collapse_Standalone {
+            get {
+                return ResourceManager.GetString("Collapse_Standalone", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to With header.</summary>
+        public static string Collapse_Header {
+            get {
+                return ResourceManager.GetString("Collapse_Header", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Stretch items.</summary>
+        public static string Layout_StackStretch {
+            get {
+                return ResourceManager.GetString("Layout_StackStretch", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Icon color and external links.</summary>
+        public static string Menu_IconColor {
+            get {
+                return ResourceManager.GetString("Menu_IconColor", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Group cascade.</summary>
+        public static string ToggleButton_GroupCascade {
+            get {
+                return ResourceManager.GetString("ToggleButton_GroupCascade", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Elevation.</summary>
+        public static string Cards_Elevation {
+            get {
+                return ResourceManager.GetString("Cards_Elevation", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Typography.</summary>
+        public static string Link_Typo {
+            get {
+                return ResourceManager.GetString("Link_Typo", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Options overload.</summary>
+        public static string Snackbar_Options {
+            get {
+                return ResourceManager.GetString("Snackbar_Options", resourceCulture);
+            }
+        }
+
+        /// <summary>Looks up a localized string similar to Shown only on md (Only + Invert).</summary>
+        public static string Responsive_ShownMd {
+            get {
+                return ResourceManager.GetString("Responsive_ShownMd", resourceCulture);
+            }
+        }
     }
 }

--- a/samples/Flare.Gallery/Resources/GalleryStrings.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.resx
@@ -2618,4 +2618,19 @@ Gallery rebuilt entirely on Flare components - no raw divs or magic code</value>
   <data name="Responsive_DesktopLayout" xml:space="preserve"><value>🖥️ Desktop layout - full multi-column experience.</value></data>
   <data name="Responsive_LastChange" xml:space="preserve"><value>Last change reported to C#:</value></data>
   <data name="Responsive_NoneYet" xml:space="preserve"><value>(none yet)</value></data>
+  <data name="Responsive_ShownMd" xml:space="preserve"><value>Shown only on md (Only + Invert).</value></data>
+  <data name="Chip_Variants" xml:space="preserve"><value>Variants</value></data>
+  <data name="Avatar_Fallback" xml:space="preserve"><value>Fallback icon</value></data>
+  <data name="Field_ErrorState" xml:space="preserve"><value>Error state (no message)</value></data>
+  <data name="Field_FullWidthMargin" xml:space="preserve"><value>Width &amp; margin</value></data>
+  <data name="Collapse_Title" xml:space="preserve"><value>Collapse</value></data>
+  <data name="Collapse_Subtitle" xml:space="preserve"><value>A standalone expand/collapse container for a single region - driven by an Expanded flag or its own optional header.</value></data>
+  <data name="Collapse_Standalone" xml:space="preserve"><value>Externally controlled</value></data>
+  <data name="Collapse_Header" xml:space="preserve"><value>With header</value></data>
+  <data name="Layout_StackStretch" xml:space="preserve"><value>Stretch items</value></data>
+  <data name="Menu_IconColor" xml:space="preserve"><value>Icon color &amp; external links</value></data>
+  <data name="ToggleButton_GroupCascade" xml:space="preserve"><value>Group cascade</value></data>
+  <data name="Cards_Elevation" xml:space="preserve"><value>Elevation</value></data>
+  <data name="Link_Typo" xml:space="preserve"><value>Typography</value></data>
+  <data name="Snackbar_Options" xml:space="preserve"><value>Options overload</value></data>
 </root>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
@@ -2618,4 +2618,19 @@ MarkdownParser: защита от vbscript/data-uri/expression()/опасных 
   <data name="Responsive_DesktopLayout" xml:space="preserve"><value>🖥️ Десктопный макет - полноценная многоколоночная раскладка.</value></data>
   <data name="Responsive_LastChange" xml:space="preserve"><value>Последнее изменение в C#:</value></data>
   <data name="Responsive_NoneYet" xml:space="preserve"><value>(пока нет)</value></data>
+  <data name="Responsive_ShownMd" xml:space="preserve"><value>Видно только на md (Only + Invert).</value></data>
+  <data name="Chip_Variants" xml:space="preserve"><value>Варианты</value></data>
+  <data name="Avatar_Fallback" xml:space="preserve"><value>Запасная иконка</value></data>
+  <data name="Field_ErrorState" xml:space="preserve"><value>Состояние ошибки (без сообщения)</value></data>
+  <data name="Field_FullWidthMargin" xml:space="preserve"><value>Ширина и отступы</value></data>
+  <data name="Collapse_Title" xml:space="preserve"><value>Сворачивание</value></data>
+  <data name="Collapse_Subtitle" xml:space="preserve"><value>Отдельный контейнер сворачивания одной области - управляется флагом Expanded или собственным заголовком.</value></data>
+  <data name="Collapse_Standalone" xml:space="preserve"><value>Внешнее управление</value></data>
+  <data name="Collapse_Header" xml:space="preserve"><value>С заголовком</value></data>
+  <data name="Layout_StackStretch" xml:space="preserve"><value>Растягивание элементов</value></data>
+  <data name="Menu_IconColor" xml:space="preserve"><value>Цвет иконок и внешние ссылки</value></data>
+  <data name="ToggleButton_GroupCascade" xml:space="preserve"><value>Каскад настроек группы</value></data>
+  <data name="Cards_Elevation" xml:space="preserve"><value>Высота тени (elevation)</value></data>
+  <data name="Link_Typo" xml:space="preserve"><value>Типографика</value></data>
+  <data name="Snackbar_Options" xml:space="preserve"><value>Перегрузка с опциями</value></data>
 </root>

--- a/src/Flare.Abstractions/Abstractions/ISnackbarService.cs
+++ b/src/Flare.Abstractions/Abstractions/ISnackbarService.cs
@@ -41,6 +41,8 @@ public enum SnackbarPosition
 /// <param name="OnAction">Optional callback invoked when the action button is pressed.</param>
 /// <param name="ShowClose">Whether a manual close button is shown.</param>
 /// <param name="ShowProgress">When true, an indeterminate progress bar is shown below the message (e.g. for an in-progress action).</param>
+/// <param name="CssClass">Optional extra CSS class(es) applied to this snackbar's root element for per-message styling.</param>
+/// <param name="CloseAfterNavigation">When true, this snackbar is dismissed automatically on the next route change.</param>
 public sealed record SnackbarMessage(
     Guid Id,
     string Text,
@@ -49,7 +51,33 @@ public sealed record SnackbarMessage(
     string? ActionText = null,
     Func<Task>? OnAction = null,
     bool ShowClose = true,
-    bool ShowProgress = false);
+    bool ShowProgress = false,
+    string? CssClass = null,
+    bool CloseAfterNavigation = false);
+
+/// <summary>
+/// Per-message options for <see cref="ISnackbarService.Show(string, SnackbarOptions)"/>: severity, timing,
+/// action button, progress bar, custom styling and navigation behavior - set once and reused or built inline.
+/// </summary>
+public sealed class SnackbarOptions
+{
+    /// <summary>Severity accent (color/icon). Default <see cref="SnackbarSeverity.Normal"/>.</summary>
+    public SnackbarSeverity Severity { get; set; } = SnackbarSeverity.Normal;
+    /// <summary>Auto-dismiss delay in milliseconds. <c>0</c> or less keeps it until dismissed. Default 4000.</summary>
+    public int DurationMs { get; set; } = 4000;
+    /// <summary>Optional action-button label; null hides the action.</summary>
+    public string? ActionText { get; set; }
+    /// <summary>Optional callback invoked when the action button is pressed.</summary>
+    public Func<Task>? OnAction { get; set; }
+    /// <summary>Whether a manual close button is shown. Default true.</summary>
+    public bool ShowClose { get; set; } = true;
+    /// <summary>When true, an indeterminate progress bar is shown below the message.</summary>
+    public bool ShowProgress { get; set; }
+    /// <summary>Optional extra CSS class(es) applied to the snackbar's root element for per-message styling.</summary>
+    public string? CssClass { get; set; }
+    /// <summary>When true, the snackbar is dismissed automatically on the next route change.</summary>
+    public bool CloseAfterNavigation { get; set; }
+}
 
 /// <summary>
 /// Imperative snackbar/toast service. Inject it and call
@@ -71,6 +99,15 @@ public interface ISnackbarService
               string? actionText = null,
               Func<Task>? onAction = null,
               bool showClose = true);
+
+    /// <summary>
+    /// Enqueues a snackbar notification configured by a <see cref="SnackbarOptions"/> bag - use this when
+    /// you need per-message styling (<see cref="SnackbarOptions.CssClass"/>), a progress bar, or the
+    /// <see cref="SnackbarOptions.CloseAfterNavigation"/> behavior that the simple overload does not expose.
+    /// </summary>
+    /// <param name="text">The message text.</param>
+    /// <param name="options">Per-message options (severity, timing, action, styling, navigation behavior).</param>
+    void Show(string text, SnackbarOptions options);
 
     /// <summary>
     /// Enqueues a pre-built snackbar. Use this (rather than the string overload) when you need to keep

--- a/src/Flare.Abstractions/Css/Classes/Chip.cs
+++ b/src/Flare.Abstractions/Css/Classes/Chip.cs
@@ -15,6 +15,10 @@ public static class Chip
     public const string Close = "flare-chip__close";
     /// <summary>The <c>flare-chip--elevated</c> CSS class.</summary>
     public const string Elevated = "flare-chip--elevated";
+    /// <summary>The <c>flare-chip--filled</c> CSS class.</summary>
+    public const string Filled = "flare-chip--filled";
+    /// <summary>The <c>flare-chip--outlined</c> CSS class.</summary>
+    public const string Outlined = "flare-chip--outlined";
     /// <summary>The <c>flare-chip--xs</c> CSS class.</summary>
     public const string SizeXs = "flare-chip--xs";
     /// <summary>The <c>flare-chip--sm</c> CSS class.</summary>

--- a/src/Flare.Abstractions/Css/Classes/Collapse.cs
+++ b/src/Flare.Abstractions/Css/Classes/Collapse.cs
@@ -1,0 +1,22 @@
+namespace Flare.Css.Classes;
+
+/// <summary>CSS classes for the standalone collapse (expand/collapse container).</summary>
+public static class Collapse
+{
+    /// <summary>The <c>flare-collapse</c> CSS class.</summary>
+    public const string Root = "flare-collapse";
+    /// <summary>The <c>flare-collapse--expanded</c> CSS class.</summary>
+    public const string Expanded = "flare-collapse--expanded";
+    /// <summary>The <c>flare-collapse--disabled</c> CSS class.</summary>
+    public const string Disabled = "flare-collapse--disabled";
+    /// <summary>The <c>flare-collapse__header</c> CSS class (the clickable toggle).</summary>
+    public const string Header = "flare-collapse__header";
+    /// <summary>The <c>flare-collapse__header-text</c> CSS class.</summary>
+    public const string HeaderText = "flare-collapse__header-text";
+    /// <summary>The <c>flare-collapse__icon</c> CSS class (header chevron).</summary>
+    public const string Icon = "flare-collapse__icon";
+    /// <summary>The <c>flare-collapse__region</c> CSS class (the animated height wrapper).</summary>
+    public const string Region = "flare-collapse__region";
+    /// <summary>The <c>flare-collapse__inner</c> CSS class (the overflow-clipped content holder).</summary>
+    public const string Inner = "flare-collapse__inner";
+}

--- a/src/Flare.Abstractions/Css/Classes/Input.cs
+++ b/src/Flare.Abstractions/Css/Classes/Input.cs
@@ -57,4 +57,10 @@ public static class Input
     public const string IconTrailing = "flare-input__icon--trailing";
     /// <summary>The <c>flare-input__label--floating</c> CSS class.</summary>
     public const string LabelFloating = "flare-input__label--floating";
+    /// <summary>The <c>flare-input--auto</c> CSS class: the field sizes to its content instead of filling its container.</summary>
+    public const string Auto = "flare-input--auto";
+    /// <summary>The <c>flare-input--margin-dense</c> CSS class: a small vertical margin around the field.</summary>
+    public const string MarginDense = "flare-input--margin-dense";
+    /// <summary>The <c>flare-input--margin-normal</c> CSS class: a normal vertical margin around the field.</summary>
+    public const string MarginNormal = "flare-input--margin-normal";
 }

--- a/src/Flare.Abstractions/Css/Classes/Snackbar.cs
+++ b/src/Flare.Abstractions/Css/Classes/Snackbar.cs
@@ -58,6 +58,10 @@ public static class Stack
     public const string ColumnReverse = "flare-stack--column-reverse";
     /// <summary>The <c>flare-stack--wrap</c> CSS class.</summary>
     public const string Wrap = "flare-stack--wrap";
+    /// <summary>The <c>flare-stack--stretch</c> CSS class: every direct child grows to share the space equally.</summary>
+    public const string Stretch = "flare-stack--stretch";
+    /// <summary>The <c>flare-stack--stretch-first</c> CSS class: the first direct child grows to fill the remaining space.</summary>
+    public const string StretchFirst = "flare-stack--stretch-first";
     /// <summary>The <c>flare-stack--gap-none</c> CSS class.</summary>
     public const string GapNone = "flare-stack--gap-none";
     /// <summary>The <c>flare-stack--gap-xxsmall</c> CSS class.</summary>

--- a/src/Flare.Components/Avatar/FlareAvatar.razor
+++ b/src/Flare.Components/Avatar/FlareAvatar.razor
@@ -19,9 +19,13 @@
         {
             <span class="@Css.Classes.Avatar.Initials" aria-label="@Text">@_initials</span>
         }
+        else if (FallbackContent is not null)
+        {
+            @FallbackContent
+        }
         else
         {
-            <span class="@Css.Classes.Avatar.Icon material-symbols-rounded" aria-hidden="true">person</span>
+            <span class="@Css.Classes.Avatar.Icon material-symbols-rounded" aria-hidden="true">@FallbackIcon</span>
         }
     </div>
 }
@@ -39,6 +43,12 @@
     [Parameter] public AvatarSize Size { get; set; } = AvatarSize.Md;
     /// <summary>Shape of the avatar: Circle, Square, or Rounded.</summary>
     [Parameter] public AvatarShape Shape { get; set; } = AvatarShape.Circle;
+    /// <summary>Material Symbols icon name shown when the avatar has no image and no text. Defaults to
+    /// <c>person</c>. Ignored when <see cref="FallbackContent"/> is set.</summary>
+    [Parameter] public string FallbackIcon { get; set; } = "person";
+    /// <summary>Custom content rendered when the avatar has no image and no text, in place of the
+    /// default <see cref="FallbackIcon"/> (e.g. a custom <c>FlareIcon</c>, an emoji, or an SVG).</summary>
+    [Parameter] public RenderFragment? FallbackContent { get; set; }
 
     /// <summary>Parent avatar group that manages max-visible and overflow counting.</summary>
     [CascadingParameter] public FlareAvatarGroup? Group { get; set; }
@@ -50,7 +60,7 @@
     private string? _lastContent;
     protected override bool ShouldRender()
     {
-        var current = $"{Src}:{Text}:{Alt}:{Color}:{Size}:{Shape}";
+        var current = $"{Src}:{Text}:{Alt}:{Color}:{Size}:{Shape}:{FallbackIcon}";
         if (current == _lastContent) return false;
         _lastContent = current;
         return true;

--- a/src/Flare.Components/Button/FlareIconButton.razor
+++ b/src/Flare.Components/Button/FlareIconButton.razor
@@ -1,0 +1,70 @@
+@namespace Flare.Components
+@inherits FlareComponentBase
+
+@* A dedicated icon-only button. Thin wrapper over FlareButton that renders the icon as the button's
+   LeadingIcon with no label, so FlareButton's square icon-only treatment applies automatically. Use
+   instead of the verbose <FlareButton><LeadingIcon><FlareIcon/></LeadingIcon></FlareButton> idiom. *@
+<FlareButton Variant="Variant"
+             Size="Size"
+             Color="Color"
+             Shape="Shape"
+             Disabled="Disabled"
+             Loading="Loading"
+             PressMorph="PressMorph"
+             Type="Type"
+             AriaPressed="AriaPressed"
+             AriaLabel="@AriaLabel"
+             Href="@Href"
+             Target="@Target"
+             OnClick="OnClick"
+             Class="@Class"
+             Style="@Style"
+             @attributes="AdditionalAttributes">
+    <LeadingIcon>
+        @if (ChildContent is not null)
+        {
+            @ChildContent
+        }
+        else if (!string.IsNullOrEmpty(Icon))
+        {
+            <FlareIcon Name="@Icon" />
+        }
+    </LeadingIcon>
+</FlareButton>
+
+@code {
+    /// <summary>Material Symbols icon name rendered inside the button (e.g. <c>settings</c>). Ignored when
+    /// <see cref="ChildContent"/> is supplied.</summary>
+    [Parameter] public string? Icon { get; set; }
+    /// <summary>Custom icon content, used in place of <see cref="Icon"/> (e.g. a configured <c>FlareIcon</c> or SVG).</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    /// <summary>Visual style variant. Defaults to <see cref="ButtonVariant.Text"/> (the MD3 "standard" icon button).</summary>
+    [Parameter] public ButtonVariant Variant { get; set; } = ButtonVariant.Text;
+    /// <summary>Size of the button.</summary>
+    [Parameter] public ButtonSize Size { get; set; } = ButtonSize.Md;
+    /// <summary>Color of the button. Role -> shared class; custom -> inline tokens. Default keeps the theme default.</summary>
+    [Parameter] public FlareColor Color { get; set; } = FlareColor.Default;
+    /// <summary>Corner shape of the button. Default keeps the theme's native (typically circular for icon buttons).</summary>
+    [Parameter] public ButtonShape Shape { get; set; } = ButtonShape.Default;
+    /// <summary>Opt-in MD3 Expressive press morph: the corner radius animates while the button is pressed.</summary>
+    [Parameter] public bool PressMorph { get; set; }
+    /// <summary>Disables the button when true.</summary>
+    [Parameter] public bool Disabled { get; set; }
+    /// <summary>Shows a spinner and disables the button when true.</summary>
+    [Parameter] public bool Loading { get; set; }
+    /// <summary>HTML type attribute of the button element (Button, Submit, or Reset).</summary>
+    [Parameter] public ButtonType Type { get; set; } = ButtonType.Button;
+    /// <summary>Indicates pressed state for toggle icon buttons, forwarded as aria-pressed.</summary>
+    [Parameter] public bool AriaPressed { get; set; }
+    /// <summary>Accessible label for the button, forwarded as aria-label. Strongly recommended for icon-only buttons.</summary>
+    [Parameter] public string? AriaLabel { get; set; }
+    /// <summary>When set, the button renders as a link (&lt;a&gt;) to this URL. Disabled/Loading removes the href.</summary>
+    [Parameter] public string? Href { get; set; }
+    /// <summary>Target for the link button (e.g. "_blank"). Only used with <see cref="Href"/>.</summary>
+    [Parameter] public string? Target { get; set; }
+    /// <summary>Callback invoked when the button is clicked.</summary>
+    [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    // This component only composes FlareButton; it has no root element of its own.
+    protected override string ComponentCssClass => string.Empty;
+}

--- a/src/Flare.Components/Button/FlareToggleButton.razor
+++ b/src/Flare.Components/Button/FlareToggleButton.razor
@@ -1,10 +1,10 @@
 @namespace Flare.Components
 @inherits FlareComponentBase
 
-<button class="@BuildCssClass(_pressedClass, _sizeClass, _iconOnlyClass)"
-        style="@Style"
+<button class="@BuildCssClass(_pressedClass, _sizeClass, _iconOnlyClass, _colorClass)"
+        style="@_btnStyle"
         type="button"
-        disabled="@Disabled"
+        disabled="@_effectiveDisabled"
         aria-label="@AriaLabel"
         aria-pressed="@(_pressed ? "true" : "false")"
         @onclick="HandleClick"
@@ -31,9 +31,12 @@
     [Parameter] public bool Toggled { get; set; }
     /// <summary>Callback raised when the pressed state changes.</summary>
     [Parameter] public EventCallback<bool> ToggledChanged { get; set; }
-    /// <summary>Size of the toggle button.</summary>
+    /// <summary>Size of the toggle button. Overridden by the parent <c>FlareToggleGroup.Size</c> when that is set.</summary>
     [Parameter] public ButtonSize Size { get; set; } = ButtonSize.Md;
-    /// <summary>Disables the button when true.</summary>
+    /// <summary>Color tinting the selected state. Role -> shared color class; custom -> inline tokens.
+    /// Overridden by the parent <c>FlareToggleGroup.Color</c> when that is set. Default = theme's secondary container.</summary>
+    [Parameter] public FlareColor Color { get; set; } = FlareColor.Default;
+    /// <summary>Disables the button when true. Also disabled when the parent <c>FlareToggleGroup.Disabled</c> is true.</summary>
     [Parameter] public bool Disabled { get; set; }
     /// <summary>Accessible label forwarded as aria-label.</summary>
     [Parameter] public string? AriaLabel { get; set; }
@@ -51,7 +54,16 @@
 
     private string _pressedClass => _pressed ? Css.Classes.ToggleButton.Pressed : string.Empty;
 
-    private string _sizeClass => Size switch
+    // Group settings cascade: a group value overrides the button's own (Size/Color), or forces Disabled.
+    private ButtonSize _effectiveSize => Group?.Size ?? Size;
+    private FlareColor _effectiveColor => Group?.Color ?? Color;
+    private bool _effectiveDisabled => Disabled || (Group?.Disabled ?? false);
+
+    // Role -> shared color class (sets --fc-container/--fc-on-container); custom -> inline those tokens.
+    private string _colorClass => _effectiveColor.CssClass ?? string.Empty;
+    private string? _btnStyle => _effectiveColor.StyleContainerSolid() is { } tokens ? tokens + Style : Style;
+
+    private string _sizeClass => _effectiveSize switch
     {
         ButtonSize.Xs => Css.Classes.ToggleButton.Xs,
         ButtonSize.Sm => Css.Classes.ToggleButton.Sm,
@@ -86,7 +98,7 @@
 
     private async Task HandleClick()
     {
-        if (Disabled) return;
+        if (_effectiveDisabled) return;
         if (Group is not null)
         {
             await Group.Toggle(Value);

--- a/src/Flare.Components/Button/FlareToggleGroup.razor
+++ b/src/Flare.Components/Button/FlareToggleGroup.razor
@@ -23,6 +23,12 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     /// <summary>"horizontal" (default) or "vertical".</summary>
     [Parameter] public string Orientation { get; set; } = "horizontal";
+    /// <summary>Size cascaded to every child <c>FlareToggleButton</c>. When null (default) each button keeps its own <c>Size</c>.</summary>
+    [Parameter] public ButtonSize? Size { get; set; }
+    /// <summary>Color cascaded to every child <c>FlareToggleButton</c> (tints the selected state). When null (default) each button keeps its own <c>Color</c>.</summary>
+    [Parameter] public FlareColor? Color { get; set; }
+    /// <summary>When true, disables every child <c>FlareToggleButton</c> in the group.</summary>
+    [Parameter] public bool Disabled { get; set; }
 
     protected override string ComponentCssClass => Css.Classes.ToggleGroup.Root;
 
@@ -31,6 +37,8 @@
 
     private HashSet<object?> _selected = new();
     private FlareToggleGroupContext _context = null!;
+    // Tracks the last cascaded settings so the context is rebuilt when they change (not only on selection change).
+    private (ButtonSize? Size, FlareColor? Color, bool Disabled) _lastCascade;
 
     protected override void OnParametersSet()
     {
@@ -38,14 +46,19 @@
             ? new HashSet<object?>(Values?.Cast<object?>() ?? Enumerable.Empty<object?>())
             : Value is not null ? new HashSet<object?> { Value } : new HashSet<object?>();
 
-        // Only rebuild context when the selection set actually changed to avoid
-        // forcing a full subtree re-render on every parent parameter set.
-        if (_context is null || !newSelected.SetEquals(_selected))
+        var cascade = (Size, Color, Disabled);
+        // Rebuild the context when the selection set OR a cascaded setting changed, to avoid
+        // forcing a full subtree re-render on every unrelated parent parameter set.
+        if (_context is null || !newSelected.SetEquals(_selected) || cascade != _lastCascade)
         {
             _selected = newSelected;
-            _context = new FlareToggleGroupContext(_selected, MultiSelect, HandleToggle);
+            _lastCascade = cascade;
+            _context = BuildContext(_selected);
         }
     }
+
+    private FlareToggleGroupContext BuildContext(IEnumerable<object?> selected)
+        => new(new HashSet<object?>(selected), MultiSelect, HandleToggle, Size, Color, Disabled);
 
     private async Task HandleToggle(object? value)
     {
@@ -54,14 +67,14 @@
             if (!_selected.Add(value))
                 _selected.Remove(value);
 
-            _context = new FlareToggleGroupContext(new HashSet<object?>(_selected), MultiSelect, HandleToggle);
+            _context = BuildContext(_selected);
             await ValuesChanged.InvokeAsync(_selected.Cast<TValue?>().ToList());
         }
         else
         {
             var next = _selected.Contains(value) ? default : (TValue?)value;
             _selected = next is not null ? new HashSet<object?> { next } : new HashSet<object?>();
-            _context = new FlareToggleGroupContext(new HashSet<object?>(_selected), MultiSelect, HandleToggle);
+            _context = BuildContext(_selected);
             await ValueChanged.InvokeAsync(next);
         }
 

--- a/src/Flare.Components/Button/FlareToggleGroupContext.cs
+++ b/src/Flare.Components/Button/FlareToggleGroupContext.cs
@@ -1,8 +1,17 @@
 namespace Flare.Components;
 
 /// <summary>Cascading context published by FlareToggleGroup to its child FlareToggleButton components.</summary>
+/// <param name="SelectedValues">The values currently selected in the group.</param>
+/// <param name="MultiSelect">Whether more than one button can be selected at once.</param>
+/// <param name="Toggle">Toggles the selection of the button with the given value.</param>
+/// <param name="Size">Size cascaded to every button (null = each button keeps its own <c>Size</c>).</param>
+/// <param name="Color">Color cascaded to every button (null = each button keeps its own <c>Color</c>).</param>
+/// <param name="Disabled">When true, every button in the group is disabled.</param>
 public sealed record FlareToggleGroupContext(
     IReadOnlySet<object?> SelectedValues,
     bool MultiSelect,
-    Func<object?, Task> Toggle
+    Func<object?, Task> Toggle,
+    ButtonSize? Size = null,
+    FlareColor? Color = null,
+    bool Disabled = false
 );

--- a/src/Flare.Components/Card/FlareCard.razor
+++ b/src/Flare.Components/Card/FlareCard.razor
@@ -4,14 +4,14 @@
 
 @if (Href is not null)
 {
-    <a class="@CssClass" style="@Style"
+    <a class="@CssClass" style="@_cardStyle"
        href="@Href" target="@Target" @attributes="AdditionalAttributes">
         @ChildContent
     </a>
 }
 else
 {
-    <div class="@CssClass" style="@Style"
+    <div class="@CssClass" style="@_cardStyle"
          role="@Role" tabindex="@(_interactive ? "0" : null)"
          aria-checked="@AriaChecked"
          @onclick="HandleClick" @onkeydown="HandleKeyDown" @attributes="AdditionalAttributes">
@@ -28,6 +28,15 @@ else
 
     /// <summary>Overall size - controls corner radius and inner gap. Default Md.</summary>
     [Parameter] public CardSize Size { get; set; } = CardSize.Md;
+
+    /// <summary>
+    /// Overrides the card's drop shadow with an explicit elevation level (0-5 on the MD3 elevation scale,
+    /// clamped). <c>Elevation="0"</c> is flat (no shadow); higher values lift the card further. When
+    /// <c>null</c> (default) each <see cref="Variant"/> keeps its own elevation - <see cref="CardVariant.Elevated"/>
+    /// is level 1, while <see cref="CardVariant.Filled"/>/<see cref="CardVariant.Outlined"/>/<see cref="CardVariant.Tonal"/>/<see cref="CardVariant.Text"/>
+    /// are flat. Because it sets the shadow inline, an explicit elevation also fixes the hover shadow of a clickable card.
+    /// </summary>
+    [Parameter] public int? Elevation { get; set; }
 
     /// <summary>When true, lays the card out horizontally (media on the leading side, content beside it), like FluentUI 2 horizontal orientation. Default false (vertical).</summary>
     [Parameter] public bool Compact { get; set; }
@@ -57,6 +66,17 @@ else
 
     private bool _clickable => Href is not null || OnClick.HasDelegate;
     private bool _interactive => _clickable || Selectable;
+
+    // Explicit Elevation -> inline box-shadow from the elevation token scale (wins over the variant class).
+    private string? _cardStyle
+    {
+        get
+        {
+            if (Elevation is not { } level) return Style;
+            var shadow = $"box-shadow:var(--flare-elevation-{Math.Clamp(level, 0, 5)});";
+            return string.IsNullOrEmpty(Style) ? shadow : shadow + Style;
+        }
+    }
 
     private string CssClass => BuildCssClass(
         _variantClass, _sizeClass,

--- a/src/Flare.Components/Chip/ChipVariant.cs
+++ b/src/Flare.Components/Chip/ChipVariant.cs
@@ -1,0 +1,19 @@
+namespace Flare.Components;
+
+/// <summary>
+/// Visual style of a <see cref="FlareChip"/>, independent of the active theme. Mirrors the chip
+/// styles in MD3: <see cref="Outlined"/> (the default - a bordered, transparent chip),
+/// <see cref="Filled"/> (a solid surface fill with no border) and <see cref="Elevated"/>
+/// (a filled surface lifted by a drop shadow).
+/// </summary>
+public enum ChipVariant
+{
+    /// <summary>Bordered chip with a transparent background (MD3 assist/filter chip). The default.</summary>
+    Outlined,
+
+    /// <summary>Solid surface fill with no border.</summary>
+    Filled,
+
+    /// <summary>Filled surface lifted by a level-1 drop shadow, with no border.</summary>
+    Elevated,
+}

--- a/src/Flare.Components/Chip/FlareChip.razor
+++ b/src/Flare.Components/Chip/FlareChip.razor
@@ -1,7 +1,7 @@
 @namespace Flare.Components
 @inherits FlareComponentBase
 
-<div class="@BuildCssClass(_resolvedSelectedClass, _sizeClass, _elevatedClass, _colorClass)" style="@_chipStyle" @attributes="AdditionalAttributes" role="button" tabindex="0" @onclick="HandleClick" @onkeydown="HandleKeyDown">
+<div class="@BuildCssClass(_resolvedSelectedClass, _sizeClass, _variantClass, _colorClass)" style="@_chipStyle" @attributes="AdditionalAttributes" role="button" tabindex="0" @onclick="HandleClick" @onkeydown="HandleKeyDown">
     @if (Avatar is not null)
     {
         <span class="@Css.Classes.Chip.Avatar">@Avatar</span>
@@ -44,7 +44,13 @@
     [Parameter] public EventCallback OnClick { get; set; }
     /// <summary>Color of the chip. Role -> shared color class; custom -> inline tokens. Default = theme default.</summary>
     [Parameter] public FlareColor Color { get; set; } = FlareColor.Default;
-    /// <summary>Renders the chip as an elevated chip (filled surface with a shadow, no border).</summary>
+    /// <summary>Visual style of the chip: <see cref="ChipVariant.Outlined"/> (default, bordered),
+    /// <see cref="ChipVariant.Filled"/> (solid surface fill) or <see cref="ChipVariant.Elevated"/>
+    /// (filled with a shadow). Setting <see cref="Elevated"/> is equivalent to
+    /// <see cref="ChipVariant.Elevated"/> and takes precedence over this parameter when true.</summary>
+    [Parameter] public ChipVariant Variant { get; set; } = ChipVariant.Outlined;
+    /// <summary>Renders the chip as an elevated chip (filled surface with a shadow, no border). Convenience
+    /// shorthand for <c>Variant="ChipVariant.Elevated"</c>; when true it overrides <see cref="Variant"/>.</summary>
     [Parameter] public bool Elevated { get; set; }
 
     /// <summary>Parent chip group context providing selection state management.</summary>
@@ -57,7 +63,14 @@
         : Selected;
 
     private string _resolvedSelectedClass => _isSelected ? Css.Classes.Chip.Selected : string.Empty;
-    private string _elevatedClass => Elevated ? Css.Classes.Chip.Elevated : string.Empty;
+    // Elevated bool is a back-compat shorthand for Variant=Elevated and wins when set.
+    private ChipVariant _effectiveVariant => Elevated ? ChipVariant.Elevated : Variant;
+    private string _variantClass => _effectiveVariant switch
+    {
+        ChipVariant.Filled   => Css.Classes.Chip.Filled,
+        ChipVariant.Elevated => Css.Classes.Chip.Elevated,
+        _                    => string.Empty, // Outlined is the base style
+    };
     private string _colorClass => Color.CssClass ?? string.Empty;
 
     // Custom/dynamic -> inline --fc-main (fg/border/selected-bg) + --fc-on (selected text).

--- a/src/Flare.Components/Collapse/FlareCollapse.razor
+++ b/src/Flare.Components/Collapse/FlareCollapse.razor
@@ -1,0 +1,86 @@
+@namespace Flare.Components
+@inherits FlareComponentBase
+
+@* Standalone expand/collapse container. Unlike FlareAccordion (a panel group), this wraps a single
+   region whose visibility is driven by the Expanded parameter - controlled externally (@bind-Expanded
+   or any toggle) or via the optional built-in header. The region animates its height open/closed. *@
+<div class="@BuildCssClass(_expanded ? Css.Classes.Collapse.Expanded : null, Disabled ? Css.Classes.Collapse.Disabled : null)"
+     style="@Style"
+     @attributes="AdditionalAttributes">
+    @if (_hasHeader)
+    {
+        <button class="@Css.Classes.Collapse.Header"
+                type="button"
+                id="@_headerId"
+                disabled="@Disabled"
+                aria-expanded="@_expanded.ToString().ToLowerInvariant()"
+                aria-controls="@_regionId"
+                @onclick="Toggle">
+            <span class="@Css.Classes.Collapse.HeaderText">
+                @if (HeaderContent is not null)
+                {
+                    @HeaderContent
+                }
+                else
+                {
+                    @Header
+                }
+            </span>
+            <FlareIcon Name="@(_expanded ? "expand_less" : "expand_more")" Class="@Css.Classes.Collapse.Icon" />
+        </button>
+    }
+    <div class="@Css.Classes.Collapse.Region"
+         id="@_regionId"
+         role="region"
+         aria-labelledby="@(_hasHeader ? _headerId : null)">
+        <div class="@Css.Classes.Collapse.Inner">
+            @ChildContent
+        </div>
+    </div>
+</div>
+
+@code {
+    /// <summary>Content revealed when the collapse is expanded.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    /// <summary>Optional header text. When set (or <see cref="HeaderContent"/>) a clickable toggle header
+    /// is rendered; otherwise the collapse is headerless and driven only by <see cref="Expanded"/>.</summary>
+    [Parameter] public string? Header { get; set; }
+    /// <summary>Rich header content (icons, badges, custom markup); overrides <see cref="Header"/> when set
+    /// and renders a clickable toggle header.</summary>
+    [Parameter] public RenderFragment? HeaderContent { get; set; }
+    /// <summary>Whether the content region is expanded. Supports two-way binding (<c>@bind-Expanded</c>).</summary>
+    [Parameter] public bool Expanded { get; set; }
+    /// <summary>Fired when the expanded state changes (enables <c>@bind-Expanded</c>).</summary>
+    [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
+    /// <summary>Disables the built-in header toggle. A headerless collapse is unaffected (it is controlled
+    /// only through <see cref="Expanded"/>).</summary>
+    [Parameter] public bool Disabled { get; set; }
+
+    protected override string ComponentCssClass => Css.Classes.Collapse.Root;
+
+    private bool _expanded;
+    private bool _lastExpanded;
+    private readonly string _id = Guid.NewGuid().ToString("N")[..8];
+    private string _headerId => $"flare-collapse-hdr-{_id}";
+    private string _regionId => $"flare-collapse-rgn-{_id}";
+    private bool _hasHeader => HeaderContent is not null || !string.IsNullOrEmpty(Header);
+
+    protected override void OnParametersSet()
+    {
+        // Adopt the Expanded parameter only when it actually changes externally; otherwise keep the
+        // local toggle state so an unbound header collapse is not reset by parent re-renders.
+        if (Expanded != _lastExpanded)
+        {
+            _expanded = Expanded;
+            _lastExpanded = Expanded;
+        }
+    }
+
+    private async Task Toggle()
+    {
+        if (Disabled) return;
+        _expanded = !_expanded;
+        _lastExpanded = _expanded;
+        await ExpandedChanged.InvokeAsync(_expanded);
+    }
+}

--- a/src/Flare.Components/Input/FieldMargin.cs
+++ b/src/Flare.Components/Input/FieldMargin.cs
@@ -1,0 +1,15 @@
+namespace Flare.Components;
+
+/// <summary>
+/// Vertical (block) margin applied around a text field (<c>FlareField</c> / <c>FlareTextField</c>),
+/// mirroring the dense/normal spacing presets common in form layouts.
+/// </summary>
+public enum FieldMargin
+{
+    /// <summary>No outer margin (the default - spacing is left to the surrounding layout).</summary>
+    None,
+    /// <summary>A small vertical margin above and below the field (compact forms).</summary>
+    Dense,
+    /// <summary>A normal vertical margin above and below the field (comfortable forms).</summary>
+    Normal,
+}

--- a/src/Flare.Components/Input/FlareField.razor
+++ b/src/Flare.Components/Input/FlareField.razor
@@ -6,7 +6,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Web
 
-<div class="@BuildCssClass(_stateClass, FloatingLabel ? Css.Classes.Input.Floating : null, AdornmentStart is not null ? Css.Classes.Input.HasAdornmentStart : null, AdornmentEnd is not null ? Css.Classes.Input.HasAdornmentEnd : null, _colorClass, _variantClass, _sizeClass)" style="@_inlineStyle">
+<div class="@BuildCssClass(_stateClass, FloatingLabel ? Css.Classes.Input.Floating : null, AdornmentStart is not null ? Css.Classes.Input.HasAdornmentStart : null, AdornmentEnd is not null ? Css.Classes.Input.HasAdornmentEnd : null, _colorClass, _variantClass, _sizeClass, _fullWidthClass, _marginClass)" style="@_inlineStyle">
     @if (!FloatingLabel && !string.IsNullOrEmpty(Label))
     {
         <label class="@Css.Classes.Input.Label" for="@_inputId">@Label</label>
@@ -30,7 +30,7 @@
                type="@Type"
                maxlength="@(MaxLength > 0 ? MaxLength.ToString() : null)"
                aria-label="@AriaLabel"
-               aria-invalid="@(!string.IsNullOrEmpty(_displayedError) ? "true" : null)"
+               aria-invalid="@(_hasError ? "true" : null)"
                aria-describedby="@_computedDescribedBy"
                @onchange="HandleChange"
                @oninput="HandleInput"
@@ -92,6 +92,14 @@
     [Parameter] public string? HelperText { get; set; }
     /// <summary>Overrides validation with a custom error message.</summary>
     [Parameter] public string? ErrorText { get; set; }
+    /// <summary>Forces the field into the error (invalid) visual state - red active indicator and
+    /// <c>aria-invalid</c> - without requiring an <see cref="ErrorText"/> message. Useful when the error
+    /// is surfaced elsewhere (a form-level summary) or when only the state, not a message, is wanted.
+    /// The error state is also shown automatically whenever <see cref="ErrorText"/> or a bound validation
+    /// message is present.</summary>
+    [Parameter] public bool Error { get; set; }
+    /// <summary>Alias for <see cref="Error"/>: forces the invalid visual state without a message.</summary>
+    [Parameter] public bool Invalid { get; set; }
     /// <summary>Icon rendered inside the leading edge of the input.</summary>
     [Parameter] public RenderFragment? LeadingIcon { get; set; }
     /// <summary>Icon rendered inside the trailing edge of the input.</summary>
@@ -127,6 +135,13 @@
     [Parameter] public InputVariant Variant { get; set; } = InputVariant.Default;
     /// <summary>Control size (Xs..Xl). Medium is the default field height.</summary>
     [Parameter] public FieldSize Size { get; set; } = FieldSize.Md;
+    /// <summary>When true (the default), the field is block-level and fills the width of its container.
+    /// Set to false to size the field to its content (inline) instead.</summary>
+    [Parameter] public bool FullWidth { get; set; } = true;
+    /// <summary>Vertical (block) margin around the field. <see cref="FieldMargin.None"/> (default) leaves
+    /// spacing to the surrounding layout; <see cref="FieldMargin.Dense"/> / <see cref="FieldMargin.Normal"/>
+    /// add a compact / comfortable margin above and below.</summary>
+    [Parameter] public FieldMargin Margin { get; set; } = FieldMargin.None;
     /// <summary>Optional typography scale for the input text. Overrides the size-derived font.
     /// Null keeps the size default.</summary>
     [Parameter] public TypographyScale? Typo { get; set; }
@@ -170,8 +185,11 @@
 
     private string? _displayedError => DisplayedError(ErrorText);
 
+    // The error state is on when explicitly toggled (Error/Invalid) or when a message is displayed.
+    private bool _hasError => Error || Invalid || !string.IsNullOrEmpty(_displayedError);
+
     private string _stateClass =>
-        !string.IsNullOrEmpty(_displayedError) ? Css.Classes.Input.Error :
+        _hasError ? Css.Classes.Input.Error :
         Disabled ? Css.Classes.Input.Disabled : string.Empty;
 
     // Role -> shared flare-color-* class (sets --fc-main); custom -> inline --fc-main token.
@@ -184,6 +202,14 @@
         FieldSize.Lg => Css.Classes.Input.SizeLg,
         FieldSize.Xl => Css.Classes.Input.SizeXl,
         _ => string.Empty,
+    };
+    // Full width is the default (no class); false -> shrink-to-content.
+    private string? _fullWidthClass => FullWidth ? null : Css.Classes.Input.Auto;
+    private string? _marginClass => Margin switch
+    {
+        FieldMargin.Dense  => Css.Classes.Input.MarginDense,
+        FieldMargin.Normal => Css.Classes.Input.MarginNormal,
+        _                  => null,
     };
     private string? _inlineStyle => Color.IsCustom ? $"{Css.Tokens.LocalColor.Main}:{Color.Value};{Style}" : Style;
     // Typo wins over the size-derived font via an inline style (the size-grid selectors out-specify a class).

--- a/src/Flare.Components/Layout/FlareStack.razor
+++ b/src/Flare.Components/Layout/FlareStack.razor
@@ -1,7 +1,7 @@
 @namespace Flare.Components
 @inherits FlareComponentBase
 
-<div class="@BuildCssClass(_dirClass, _wrapClass, _gapClass, _alignClass, _justifyClass)"
+<div class="@BuildCssClass(_dirClass, _wrapClass, _stretchClass, _gapClass, _alignClass, _justifyClass)"
      style="@_resolvedStyle"
      @attributes="AdditionalAttributes">
     @ChildContent
@@ -20,6 +20,13 @@
     [Parameter] public string? GapValue { get; set; }
     /// <summary>Allows children to wrap onto multiple lines.</summary>
     [Parameter] public bool Wrap { get; set; }
+    /// <summary>When true, every direct child grows to share the available space equally along the main
+    /// axis (each child gets <c>flex: 1 1 0</c>). Use it to make items fill a row/column evenly.</summary>
+    [Parameter] public bool StretchItems { get; set; }
+    /// <summary>When true, only the first direct child grows to fill the remaining main-axis space
+    /// (<c>flex: 1 1 auto</c>) while the others keep their natural size - e.g. a title that expands to
+    /// push trailing actions to the edge. Ignored when <see cref="StretchItems"/> is set.</summary>
+    [Parameter] public bool StretchFirst { get; set; }
     /// <summary>Cross-axis alignment of children.</summary>
     [Parameter] public FlareAlignItems Align { get; set; } = FlareAlignItems.Default;
     /// <summary>Main-axis justification of children.</summary>
@@ -32,6 +39,11 @@
     : (Reverse ? Css.Classes.Stack.ColumnReverse : Css.Classes.Stack.Column);
 
     private string _wrapClass => Wrap ? Css.Classes.Stack.Wrap : string.Empty;
+
+    // StretchItems (all children grow equally) wins over StretchFirst (only the first grows).
+    private string _stretchClass => StretchItems ? Css.Classes.Stack.Stretch
+        : StretchFirst ? Css.Classes.Stack.StretchFirst
+        : string.Empty;
 
     private string? _gapClass;
     private string? _alignClass;

--- a/src/Flare.Components/Link/FlareLink.razor
+++ b/src/Flare.Components/Link/FlareLink.razor
@@ -3,7 +3,7 @@
 
 @if (!string.IsNullOrEmpty(Href) && !Disabled)
 {
-    <a class="@BuildCssClass(_colorClass, _underlineClass)"
+    <a class="@BuildCssClass(_colorClass, _underlineClass, _typoClass)"
        href="@_safeHref"
        target="@Target"
        rel="@(Target == "_blank" ? "noopener noreferrer" : null)"
@@ -13,7 +13,7 @@
 }
 else
 {
-    <span class="@BuildCssClass(_colorClass, _underlineClass, Disabled ? Css.Classes.Link.Disabled : null)"
+    <span class="@BuildCssClass(_colorClass, _underlineClass, _typoClass, Disabled ? Css.Classes.Link.Disabled : null)"
           role="link"
           aria-disabled="@Disabled.ToString().ToLower()"
           style="@_inlineStyle"
@@ -31,6 +31,9 @@ else
     [Parameter] public FlareColor       Color        { get; set; } = FlareColor.Primary;
     /// <summary>Underline behavior: Always, Hover, or None.</summary>
     [Parameter] public LinkUnderline    Underline    { get; set; } = LinkUnderline.Hover;
+    /// <summary>Optional type-scale applied to the link text (font family/size/weight/line-height).
+    /// When <c>null</c> (default) the link inherits the surrounding text's typography.</summary>
+    [Parameter] public TypographyScale? Typo         { get; set; }
     /// <summary>Renders the link as a non-interactive disabled span.</summary>
     [Parameter] public bool             Disabled     { get; set; }
     /// <summary>Tooltip text rendered as the HTML title attribute for accessibility.</summary>
@@ -53,5 +56,26 @@ else
         LinkUnderline.Always => Css.Classes.Link.UnderlineAlways,
         LinkUnderline.None   => Css.Classes.Link.UnderlineNone,
         _                    => Css.Classes.Link.UnderlineHover,
+    };
+
+    // Optional type-scale override via the shared flare-text--* utility classes (null -> inherit).
+    private string? _typoClass => Typo switch
+    {
+        TypographyScale.DisplayLarge   => Css.Classes.Text.DisplayLarge,
+        TypographyScale.DisplayMedium  => Css.Classes.Text.DisplayMedium,
+        TypographyScale.DisplaySmall   => Css.Classes.Text.DisplaySmall,
+        TypographyScale.HeadlineLarge  => Css.Classes.Text.HeadlineLarge,
+        TypographyScale.HeadlineMedium => Css.Classes.Text.HeadlineMedium,
+        TypographyScale.HeadlineSmall  => Css.Classes.Text.HeadlineSmall,
+        TypographyScale.TitleLarge     => Css.Classes.Text.TitleLarge,
+        TypographyScale.TitleMedium    => Css.Classes.Text.TitleMedium,
+        TypographyScale.TitleSmall     => Css.Classes.Text.TitleSmall,
+        TypographyScale.BodyLarge      => Css.Classes.Text.BodyLarge,
+        TypographyScale.BodyMedium     => Css.Classes.Text.BodyMedium,
+        TypographyScale.BodySmall      => Css.Classes.Text.BodySmall,
+        TypographyScale.LabelLarge     => Css.Classes.Text.LabelLarge,
+        TypographyScale.LabelMedium    => Css.Classes.Text.LabelMedium,
+        TypographyScale.LabelSmall     => Css.Classes.Text.LabelSmall,
+        _                              => null,
     };
 }

--- a/src/Flare.Components/Menu/FlareMenuItem.razor
+++ b/src/Flare.Components/Menu/FlareMenuItem.razor
@@ -7,6 +7,8 @@
        id="@ItemId"
        role="menuitem"
        href="@_safeHref"
+       target="@Target"
+       rel="@_rel"
        tabindex="@_tabIndex"
        aria-disabled="@Disabled.ToString().ToLowerInvariant()"
        style="@Style"
@@ -15,7 +17,7 @@
        @attributes="AdditionalAttributes">
         @if (!string.IsNullOrEmpty(Icon))
         {
-            <span class="@Css.Classes.Menu.ItemIcon material-symbols-rounded" aria-hidden="true">@Icon</span>
+            <span class="@Css.Classes.Menu.ItemIcon material-symbols-rounded @_iconColorClass" style="@_iconColorStyle" aria-hidden="true">@Icon</span>
         }
         <span class="@Css.Classes.Menu.ItemLabel">@ChildContent</span>
     </a>
@@ -33,7 +35,7 @@ else
             @attributes="AdditionalAttributes">
         @if (!string.IsNullOrEmpty(Icon))
         {
-            <span class="@Css.Classes.Menu.ItemIcon material-symbols-rounded" aria-hidden="true">@Icon</span>
+            <span class="@Css.Classes.Menu.ItemIcon material-symbols-rounded @_iconColorClass" style="@_iconColorStyle" aria-hidden="true">@Icon</span>
         }
         <span class="@Css.Classes.Menu.ItemLabel">@ChildContent</span>
     </button>
@@ -48,6 +50,15 @@ else
     [Parameter] public bool Disabled { get; set; }
     /// <summary>URL the menu item navigates to. When set renders an anchor element instead of a button.</summary>
     [Parameter] public string? Href { get; set; }
+    /// <summary>HTML <c>target</c> for the anchor when <see cref="Href"/> is set (e.g. <c>_blank</c> to open
+    /// an external link in a new tab). A <c>_blank</c> target automatically adds <c>rel="noopener noreferrer"</c>.
+    /// Ignored when the item renders as a button (no <see cref="Href"/>).</summary>
+    [Parameter] public string? Target { get; set; }
+    /// <summary>Color of the leading <see cref="Icon"/>. Role -> shared color class; custom -> inline token.
+    /// Default keeps the theme's neutral icon color.</summary>
+    [Parameter] public FlareColor IconColor { get; set; } = FlareColor.Default;
+    /// <summary>Alias for <see cref="IconColor"/>; when set (non-default) it overrides <see cref="IconColor"/>.</summary>
+    [Parameter] public FlareColor LeadingIconColor { get; set; } = FlareColor.Default;
     /// <summary>Callback raised when the menu item is clicked.</summary>
     [Parameter] public EventCallback OnClick { get; set; }
 
@@ -82,6 +93,17 @@ else
         href.StartsWith("tel:", StringComparison.OrdinalIgnoreCase);
 
     private string _safeHref => IsHrefSafe(Href) ? Href! : "about:blank";
+
+    // A _blank target needs rel=noopener noreferrer to prevent reverse-tabnabbing.
+    private string? _rel => Target == "_blank" ? "noopener noreferrer" : null;
+
+    // LeadingIconColor (alias) overrides IconColor when set to a non-default color.
+    private FlareColor _effectiveIconColor => LeadingIconColor != FlareColor.Default ? LeadingIconColor : IconColor;
+    private string _iconColorClass => _effectiveIconColor.CssClass ?? string.Empty;
+    // Custom color -> inline --fc-main on the icon span; the icon CSS reads var(--fc-main, fallback).
+    private string? _iconColorStyle => _effectiveIconColor.IsCustom
+        ? $"{Css.Tokens.LocalColor.Main}:{_effectiveIconColor.Value};"
+        : null;
 
     /// <summary>Registers this item with the parent <see cref="FlareMenu"/> for keyboard navigation.</summary>
     protected override void OnInitialized()

--- a/src/Flare.Components/Select/FlareSelect.razor
+++ b/src/Flare.Components/Select/FlareSelect.razor
@@ -1,8 +1,12 @@
 @namespace Flare.Components
 @inherits FlareFieldBase
 @typeparam TValue
+@using System.ComponentModel
 @using System.Linq.Expressions
+@using System.Text
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Rendering
+@using Microsoft.AspNetCore.Components.RenderTree
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
 @inject Flare.Components.Services.IOverlayJsService Overlay
@@ -28,9 +32,9 @@
          @onkeydown="HandleKeyDown">
         <span class="@Css.Classes.Select.Value">
             @{ var selIdx = _ordered.FindIndex(i => EqualityComparer<TValue>.Default.Equals(i, Value)); }
-            @if (selIdx >= 0 && (ItemTemplate is not null || !string.IsNullOrEmpty(LabelOf(_ordered[selIdx]))))
+            @if (selIdx >= 0 && (_effectiveItemTemplate is not null || !string.IsNullOrEmpty(LabelOf(_ordered[selIdx]))))
             {
-                @if (ItemTemplate is not null) { @ItemTemplate(_ordered[selIdx]) }
+                @if (_effectiveItemTemplate is not null) { @_effectiveItemTemplate(_ordered[selIdx]) }
                 else { @LabelOf(_ordered[selIdx]) }
             }
             else
@@ -46,7 +50,7 @@
                       @ref="_listbox"
                       Items="_ordered"
                       GroupBy="GroupBy"
-                      ItemTemplate="ItemTemplate"
+                      ItemTemplate="_effectiveItemTemplate"
                       ItemLabel="LabelOf"
                       Selected="@(i => EqualityComparer<TValue>.Default.Equals(i, Value))"
                       ShowCheck="true"
@@ -80,8 +84,13 @@
     [Parameter] public string? HelperText { get; set; }
     /// <summary>Overrides validation with a custom error message.</summary>
     [Parameter] public string? ErrorText { get; set; }
-    /// <summary>Collection of items to populate the dropdown.</summary>
+    /// <summary>Collection of items to populate the dropdown. An alternative to declaring
+    /// <c>FlareSelectItem</c> children via <see cref="ChildContent"/>.</summary>
     [Parameter] public IEnumerable<TValue>? Items { get; set; }
+    /// <summary>Declarative options as native <c>&lt;option value=".."&gt;Label&lt;/option&gt;</c> child markup.
+    /// Each option's <c>value</c> attribute is converted to <c>TValue</c> and its inner text is the label.
+    /// Used instead of (and taking precedence over) the <see cref="Items"/> collection when supplied.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
     /// <summary>Function that returns the display text for an item.</summary>
     [Parameter] public Func<TValue, string>? ItemLabel { get; set; }
     /// <summary>Custom render template for an item (control + dropdown). Overrides <see cref="ItemLabel"/> text.</summary>
@@ -110,22 +119,150 @@
     private string _errorId  => $"{_selectId}-err";
     private string _helperId => $"{_selectId}-help";
 
+    // Declarative <option> values/labels parsed from ChildContent (in declaration order).
+    private bool _declarative => ChildContent is not null;
+    private List<TValue> _declaredValues = new();
+    private readonly Dictionary<TValue, string> _declaredLabels = new();
+
     // The options flattened in display order (groups kept contiguous) for keyboard nav + index alignment
-    // with the shared FlareListbox, which renders group headers at group boundaries.
+    // with the shared FlareListbox, which renders group headers at group boundaries. Declarative
+    // <option> children take precedence over the Items collection.
     private List<TValue> _ordered
     {
         get
         {
-            var src = GroupBy is null
-                ? (Items ?? Enumerable.Empty<TValue>())
-                : (Items ?? Enumerable.Empty<TValue>()).GroupBy(GroupBy).SelectMany(g => g);
-            return src.ToList();
+            var values = _declarative ? _declaredValues : (Items ?? Enumerable.Empty<TValue>());
+            return (GroupBy is null ? values : values.GroupBy(GroupBy).SelectMany(g => g)).ToList();
         }
     }
 
-    private string LabelOf(TValue item) => ItemLabel?.Invoke(item) ?? item?.ToString() ?? string.Empty;
+    // ItemTemplate (explicit) wins; declarative <option> labels render as plain text via LabelOf.
+    private RenderFragment<TValue>? _effectiveItemTemplate => ItemTemplate;
 
-    protected override void OnParametersSet() => UpdateFieldIdentifier(For);
+    private string LabelOf(TValue item)
+    {
+        if (ItemLabel is not null) return ItemLabel(item);
+        if (_declarative && item is not null && _declaredLabels.TryGetValue(item, out var text)) return text;
+        return item?.ToString() ?? string.Empty;
+    }
+
+    protected override void OnParametersSet()
+    {
+        UpdateFieldIdentifier(For);
+        ParseDeclaredOptions();
+    }
+
+    // Collects declarative <option value="..">Label</option> entries from ChildContent. Static option
+    // markup is compiled by Razor into a single Markup frame (a raw HTML string), while options carrying
+    // a binding/dynamic attribute become Element frames - so both shapes are handled. The option's value
+    // attribute is converted to TValue (TypeConverter); its inner text is the label.
+    private void ParseDeclaredOptions()
+    {
+        if (ChildContent is null)
+        {
+            if (_declaredValues.Count > 0) { _declaredValues = new(); _declaredLabels.Clear(); }
+            return;
+        }
+
+        var values = new List<TValue>();
+        _declaredLabels.Clear();
+
+        void AddOption(string? rawValue, string labelText)
+        {
+            var converted = ConvertRaw(rawValue ?? labelText);
+            if (converted is null) return;
+            values.Add(converted);
+            _declaredLabels[converted] = labelText;
+        }
+
+        var builder = new RenderTreeBuilder();
+        try
+        {
+            ChildContent(builder);
+            var range = builder.GetFrames();
+            var frames = range.Array;
+            for (var i = 0; i < range.Count; i++)
+            {
+                ref readonly var frame = ref frames[i];
+
+                // Static option markup -> one Markup frame holding the raw HTML string.
+                if (frame.FrameType == RenderTreeFrameType.Markup)
+                {
+                    ParseOptionsFromHtml(frame.MarkupContent, AddOption);
+                    continue;
+                }
+
+                // Dynamic option -> an <option> Element frame with its attributes/text as child frames.
+                if (frame.FrameType != RenderTreeFrameType.Element ||
+                    !string.Equals(frame.ElementName, "option", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                string? optionValue = null;
+                var label = new StringBuilder();
+                var end = i + frame.ElementSubtreeLength;
+                for (var j = i + 1; j < end; j++)
+                {
+                    ref readonly var child = ref frames[j];
+                    if (child.FrameType == RenderTreeFrameType.Attribute)
+                    {
+                        if (string.Equals(child.AttributeName, "value", StringComparison.OrdinalIgnoreCase))
+                            optionValue = child.AttributeValue?.ToString();
+                    }
+                    else if (child.FrameType is RenderTreeFrameType.Text or RenderTreeFrameType.Markup)
+                    {
+                        label.Append(child.TextContent);
+                    }
+                }
+                i = end - 1; // skip the option's subtree
+
+                AddOption(optionValue, label.ToString().Trim());
+            }
+        }
+        finally
+        {
+            ((IDisposable)builder).Dispose();
+        }
+
+        _declaredValues = values;
+    }
+
+    // Extracts <option value="..">label</option> entries from a raw HTML string (static markup case).
+    private static readonly System.Text.RegularExpressions.Regex _optionRegex = new(
+        "<option\\b([^>]*)>(.*?)</option>",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Singleline);
+    private static readonly System.Text.RegularExpressions.Regex _valueAttrRegex = new(
+        "value\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)')",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+    private static readonly System.Text.RegularExpressions.Regex _tagRegex = new("<[^>]+>");
+
+    private static void ParseOptionsFromHtml(string? html, Action<string?, string> add)
+    {
+        if (string.IsNullOrEmpty(html) || html.IndexOf("<option", StringComparison.OrdinalIgnoreCase) < 0)
+            return;
+        foreach (System.Text.RegularExpressions.Match m in _optionRegex.Matches(html))
+        {
+            var attrs = m.Groups[1].Value;
+            var vm = _valueAttrRegex.Match(attrs);
+            string? value = vm.Success ? (vm.Groups[1].Success ? vm.Groups[1].Value : vm.Groups[2].Value) : null;
+            var label = System.Net.WebUtility.HtmlDecode(_tagRegex.Replace(m.Groups[2].Value, string.Empty)).Trim();
+            add(value, label);
+        }
+    }
+
+    // Converts an <option> string value to TValue (identity for string; TypeConverter otherwise).
+    private static TValue? ConvertRaw(string raw)
+    {
+        if (typeof(TValue) == typeof(string)) return (TValue)(object)raw;
+        var target = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+        try
+        {
+            var converter = TypeDescriptor.GetConverter(target);
+            if (converter.CanConvertFrom(typeof(string)))
+                return (TValue?)converter.ConvertFromInvariantString(raw);
+        }
+        catch { }
+        return default;
+    }
 
     public override async ValueTask DisposeAsync()
     {

--- a/src/Flare.Components/Snackbar/FlareSnackbarProvider.razor
+++ b/src/Flare.Components/Snackbar/FlareSnackbarProvider.razor
@@ -1,12 +1,13 @@
 @namespace Flare.Components
 @inherits FlareComponentBase
 @inject ISnackbarService SnackbarService
+@inject NavigationManager Navigation
 
 <div class="@Css.Classes.Snackbar.Provider @_positionClass" aria-live="polite" aria-atomic="false">
     @foreach (var msg in _messages)
     {
         var m = msg;
-        <div class="@BuildCssClass(Css.Classes.Snackbar.Root, $"flare-snackbar--{m.Severity.ToString().ToLowerInvariant()}", m.ShowProgress ? Css.Classes.Snackbar.WithProgress : null)"
+        <div class="@BuildCssClass(Css.Classes.Snackbar.Root, $"flare-snackbar--{m.Severity.ToString().ToLowerInvariant()}", m.ShowProgress ? Css.Classes.Snackbar.WithProgress : null, m.CssClass)"
              role="status">
             <span class="@Css.Classes.Snackbar.Text">@m.Text</span>
             <div class="@Css.Classes.Snackbar.Actions">
@@ -61,7 +62,16 @@
         base.OnInitialized();
         SnackbarService.OnShow += HandleShow;
         SnackbarService.OnUpdate += HandleUpdate;
+        Navigation.LocationChanged += HandleLocationChanged;
     }
+
+    // Dismiss any message flagged CloseAfterNavigation when the route changes.
+    private void HandleLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+        => InvokeAsync(() =>
+        {
+            if (_messages.RemoveAll(m => m.CloseAfterNavigation) > 0)
+                StateHasChanged();
+        });
 
     private void HandleShow(SnackbarMessage msg)
     {
@@ -105,6 +115,7 @@
     {
         SnackbarService.OnShow -= HandleShow;
         SnackbarService.OnUpdate -= HandleUpdate;
+        Navigation.LocationChanged -= HandleLocationChanged;
         await base.DisposeAsync();
     }
 }

--- a/src/Flare.Components/wwwroot/css/chip.css
+++ b/src/Flare.Components/wwwroot/css/chip.css
@@ -48,6 +48,19 @@
 }
 .flare-chip--elevated:hover { box-shadow: var(--flare-elevation-2); }
 
+/* Filled chip: solid surface fill, no border, no shadow. A Color role tints the
+   foreground (label/icon) via --fc-main while the fill stays a neutral surface tone. */
+.flare-chip--filled {
+    background-color: var(--flare-color-surface-container-high);
+    border-color: transparent;
+}
+
+/* Outlined chip is the base style; the explicit modifier exists for parity/overrides. */
+.flare-chip--outlined {
+    background-color: transparent;
+    border: 1px solid var(--fc-main, var(--flare-color-outline));
+}
+
 .flare-chip--xs { padding: var(--flare-spacing-1, 0.125rem) var(--flare-spacing-4, 0.5rem); font-size: var(--flare-typescale-label-small-size); gap: var(--flare-spacing-2, 0.25rem); }
 .flare-chip--xs .flare-chip__avatar { width: 1rem; height: 1rem; }
 .flare-chip--sm { padding: var(--flare-spacing-2, 0.25rem) var(--flare-spacing-5, 0.625rem); font-size: var(--flare-typescale-label-small-size); gap: var(--flare-spacing-3, 0.375rem); }

--- a/src/Flare.Components/wwwroot/css/collapse.css
+++ b/src/Flare.Components/wwwroot/css/collapse.css
@@ -1,0 +1,63 @@
+/* Standalone expand/collapse container. The region animates its height via the grid-rows
+   0fr -> 1fr technique, which handles arbitrary content height without a magic max-height cap. */
+.flare-collapse {
+    display: block;
+}
+
+.flare-collapse__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    gap: var(--flare-spacing-4, 0.5rem);
+    padding: var(--flare-spacing-6, 0.75rem) var(--flare-spacing-8, 1rem);
+    background: transparent;
+    color: var(--flare-color-on-surface);
+    font-family: var(--flare-typescale-title-small-font);
+    font-size: var(--flare-typescale-title-small-size);
+    font-weight: var(--flare-typescale-title-small-weight);
+    border: none;
+    border-radius: var(--flare-shape-small);
+    cursor: pointer;
+    text-align: left;
+    transition: background var(--flare-motion-duration-short1) var(--flare-motion-easing-standard);
+}
+
+.flare-collapse__header:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--flare-color-on-surface) calc(var(--flare-state-hover-opacity) * 100%), transparent);
+}
+
+.flare-collapse--disabled .flare-collapse__header {
+    cursor: not-allowed;
+    opacity: var(--flare-state-disabled-opacity, 0.38);
+}
+
+.flare-collapse__header-text {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--flare-spacing-4, 0.5rem);
+    flex: 1;
+    min-width: 0;
+}
+
+.flare-collapse__icon {
+    flex-shrink: 0;
+    color: var(--flare-color-on-surface-variant);
+    transition: transform var(--flare-motion-duration-short2) var(--flare-motion-easing-standard);
+}
+
+.flare-collapse__region {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows var(--flare-motion-duration-medium1) var(--flare-motion-easing-standard);
+}
+
+.flare-collapse--expanded > .flare-collapse__region {
+    grid-template-rows: 1fr;
+}
+
+/* Clip the content while the grid row collapses to 0fr. min-height:0 lets the grid track shrink. */
+.flare-collapse__inner {
+    overflow: hidden;
+    min-height: 0;
+}

--- a/src/Flare.Components/wwwroot/css/flare-components.css
+++ b/src/Flare.Components/wwwroot/css/flare-components.css
@@ -33,6 +33,7 @@
 @import 'progress.css';
 @import 'tooltip.css';
 @import 'accordion.css';
+@import 'collapse.css';
 @import 'snackbar.css';
 @import 'datagrid.css';
 @import 'alert.css';

--- a/src/Flare.Components/wwwroot/css/input.css
+++ b/src/Flare.Components/wwwroot/css/input.css
@@ -5,6 +5,13 @@
     position: relative;
 }
 
+/* FullWidth=false: size to content instead of filling the container. */
+.flare-input--auto { display: inline-flex; width: auto; }
+
+/* Margin presets: vertical (block) spacing around the field. */
+.flare-input--margin-dense  { margin-block: var(--flare-spacing-2, 0.25rem); }
+.flare-input--margin-normal { margin-block: var(--flare-spacing-4, 0.5rem); }
+
 /* Per-field variant override (independent of theme) - drives the shared --flare-input-* tokens.
    Applied to FlareInput / FlareNumericField / FlareTextArea roots. Default = theme decides. */
 .flare-input-variant--filled {

--- a/src/Flare.Components/wwwroot/css/menuitem.css
+++ b/src/Flare.Components/wwwroot/css/menuitem.css
@@ -73,7 +73,8 @@
 
 .flare-menu-item__icon {
     font-size: var(--flare-menu-item-icon-size, 1.25rem);
-    color: var(--flare-color-on-surface-variant);
+    /* IconColor (role class or inline) sets --fc-main; default stays the neutral icon color. */
+    color: var(--fc-main, var(--flare-color-on-surface-variant));
     font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
     flex-shrink: 0;
 }

--- a/src/Flare.Components/wwwroot/css/stack.css
+++ b/src/Flare.Components/wwwroot/css/stack.css
@@ -23,6 +23,12 @@
 
 .flare-stack--wrap { flex-wrap: wrap; }
 
+/* Stretch: every direct child shares the main-axis space equally. min-width/height:0
+   lets children shrink below their content size so long content does not overflow. */
+.flare-stack--stretch > * { flex: 1 1 0; min-width: 0; min-height: 0; }
+/* Stretch-first: only the first child grows to fill the remaining space. */
+.flare-stack--stretch-first > :first-child { flex: 1 1 auto; min-width: 0; min-height: 0; }
+
 /* Gap modifiers */
 .flare-stack--gap-none     { gap: 0; }
 .flare-stack--gap-xxsmall  { gap: var(--flare-spacing-2, 0.25rem); }

--- a/src/Flare.Components/wwwroot/css/togglebutton.css
+++ b/src/Flare.Components/wwwroot/css/togglebutton.css
@@ -47,8 +47,9 @@
 /* Pressed/active (selected) - морфинг формы (round -> squircle) задаётся токеном размера.
    Локальная переменная --_toggle-radius-selected переключается размерными классами ниже. */
 .flare-toggle-btn--pressed {
-    background: var(--flare-toggle-btn-selected-bg, var(--flare-color-secondary-container));
-    color: var(--flare-toggle-btn-selected-color, var(--flare-color-on-secondary-container));
+    /* Color (role class / inline) sets --fc-container/--fc-on-container; default keeps the theme token. */
+    background: var(--fc-container, var(--flare-toggle-btn-selected-bg, var(--flare-color-secondary-container)));
+    color: var(--fc-on-container, var(--flare-toggle-btn-selected-color, var(--flare-color-on-secondary-container)));
     border-radius: var(--_toggle-radius-selected, var(--flare-toggle-btn-radius-selected-md, var(--flare-shape-medium, 0.75rem)));
 }
 
@@ -161,8 +162,8 @@
     border-radius: 0 0 var(--flare-togglegroup-radius-vertical, var(--flare-shape-medium, 0.75rem)) var(--flare-togglegroup-radius-vertical, var(--flare-shape-medium, 0.75rem));
 }
 
-/* Pressed state in group - show filled indicator */
+/* Pressed state in group - show filled indicator (color via --fc-container when a Color is set) */
 .flare-togglegroup > .flare-toggle-btn--pressed {
-    background: var(--flare-toggle-btn-selected-bg, var(--flare-color-secondary-container));
-    color: var(--flare-toggle-btn-selected-color, var(--flare-color-on-secondary-container));
+    background: var(--fc-container, var(--flare-toggle-btn-selected-bg, var(--flare-color-secondary-container)));
+    color: var(--fc-on-container, var(--flare-toggle-btn-selected-color, var(--flare-color-on-secondary-container)));
 }

--- a/src/Flare.Infrastructure/Feedback/SnackbarService.cs
+++ b/src/Flare.Infrastructure/Feedback/SnackbarService.cs
@@ -20,6 +20,16 @@ public sealed class SnackbarService : ISnackbarService
                      bool showClose = true)
         => OnShow?.Invoke(new SnackbarMessage(Guid.NewGuid(), text, severity, durationMs, actionText, onAction, showClose));
 
+    /// <summary>Enqueues a snackbar notification configured by a <see cref="SnackbarOptions"/> bag.</summary>
+    public void Show(string text, SnackbarOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        OnShow?.Invoke(new SnackbarMessage(
+            Guid.NewGuid(), text, options.Severity, options.DurationMs,
+            options.ActionText, options.OnAction, options.ShowClose, options.ShowProgress,
+            options.CssClass, options.CloseAfterNavigation));
+    }
+
     /// <summary>Enqueues a pre-built snackbar (the caller owns its <see cref="SnackbarMessage.Id"/>).</summary>
     public void Show(SnackbarMessage message)
     {

--- a/tests/Flare.Components.Tests/Component/MigrationApiGapsTests.cs
+++ b/tests/Flare.Components.Tests/Component/MigrationApiGapsTests.cs
@@ -1,0 +1,557 @@
+using Flare.Abstractions;
+using Flare.Infrastructure;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Flare.Components.Tests.Component;
+
+// Coverage for the small generic API additions surfaced by the PlaylistShared migration.
+
+// ------------------------------------------------------------------------------
+// FlareIconButton  (icon-only wrapper over FlareButton)
+// ------------------------------------------------------------------------------
+public class C_FlareIconButtonTests : FlareTestContext
+{
+    [Fact]
+    public void Icon_RendersIconOnlyButton()
+    {
+        var cut = Render<FlareIconButton>(p => p
+            .Add(x => x.Icon, "settings")
+            .Add(x => x.AriaLabel, "Settings"));
+
+        var btn = cut.Find("button.flare-btn");
+        Assert.Contains("flare-btn--icon-only", btn.ClassName);
+        Assert.Equal("Settings", btn.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void DefaultVariant_IsText()
+    {
+        var cut = Render<FlareIconButton>(p => p
+            .Add(x => x.Icon, "add")
+            .Add(x => x.AriaLabel, "Add"));
+
+        Assert.Contains("flare-btn--text", cut.Find("button.flare-btn").ClassName);
+    }
+
+    [Fact]
+    public void Href_RendersAnchor()
+    {
+        var cut = Render<FlareIconButton>(p => p
+            .Add(x => x.Icon, "open_in_new")
+            .Add(x => x.Href, "https://example.com")
+            .Add(x => x.AriaLabel, "Open"));
+
+        Assert.NotEmpty(cut.FindAll("a.flare-btn"));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareChip Variant
+// ------------------------------------------------------------------------------
+public class C_FlareChipVariantTests : FlareTestContext
+{
+    [Fact]
+    public void FilledVariant_AddsFilledClass()
+    {
+        var cut = Render<FlareChip>(p => p
+            .Add(x => x.Label, "Tag")
+            .Add(x => x.Variant, ChipVariant.Filled));
+
+        Assert.Contains("flare-chip--filled", cut.Find(".flare-chip").ClassName);
+    }
+
+    [Fact]
+    public void ElevatedVariant_AddsElevatedClass()
+    {
+        var cut = Render<FlareChip>(p => p
+            .Add(x => x.Label, "Tag")
+            .Add(x => x.Variant, ChipVariant.Elevated));
+
+        Assert.Contains("flare-chip--elevated", cut.Find(".flare-chip").ClassName);
+    }
+
+    [Fact]
+    public void OutlinedVariant_IsDefault_NoVariantModifier()
+    {
+        var cut = Render<FlareChip>(p => p.Add(x => x.Label, "Tag"));
+
+        var cls = cut.Find(".flare-chip").ClassName;
+        Assert.DoesNotContain("flare-chip--filled", cls);
+        Assert.DoesNotContain("flare-chip--elevated", cls);
+    }
+
+    [Fact]
+    public void ElevatedBool_StillMapsToElevated()
+    {
+        var cut = Render<FlareChip>(p => p
+            .Add(x => x.Label, "Tag")
+            .Add(x => x.Elevated, true));
+
+        Assert.Contains("flare-chip--elevated", cut.Find(".flare-chip").ClassName);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareAvatar FallbackIcon / FallbackContent
+// ------------------------------------------------------------------------------
+public class C_FlareAvatarFallbackTests : FlareTestContext
+{
+    [Fact]
+    public void NoImageNoText_DefaultsToPersonIcon()
+    {
+        var cut = Render<FlareAvatar>();
+
+        Assert.Equal("person", cut.Find(".flare-avatar__icon").TextContent);
+    }
+
+    [Fact]
+    public void FallbackIcon_OverridesDefault()
+    {
+        var cut = Render<FlareAvatar>(p => p.Add(x => x.FallbackIcon, "group"));
+
+        Assert.Equal("group", cut.Find(".flare-avatar__icon").TextContent);
+    }
+
+    [Fact]
+    public void FallbackContent_ReplacesIcon()
+    {
+        var cut = Render<FlareAvatar>(p => p
+            .Add(x => x.FallbackContent, b => b.AddMarkupContent(0, "<span class=\"custom-fb\">x</span>")));
+
+        Assert.NotEmpty(cut.FindAll(".custom-fb"));
+        Assert.Empty(cut.FindAll(".flare-avatar__icon"));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareField / FlareTextField Error + FullWidth + Margin
+// ------------------------------------------------------------------------------
+public class C_FlareFieldErrorLayoutTests : FlareTestContext
+{
+    [Fact]
+    public void Error_AddsErrorState_WithoutMessage()
+    {
+        var cut = Render<FlareTextField>(p => p.Add(x => x.Error, true));
+
+        Assert.Contains("flare-input--error", cut.Find(".flare-input").ClassName);
+        // No error message row is forced when there is no ErrorText.
+        Assert.Empty(cut.FindAll(".flare-input__helper--error"));
+        Assert.Equal("true", cut.Find("input.flare-input__control").GetAttribute("aria-invalid"));
+    }
+
+    [Fact]
+    public void Invalid_Alias_AddsErrorState()
+    {
+        var cut = Render<FlareTextField>(p => p.Add(x => x.Invalid, true));
+
+        Assert.Contains("flare-input--error", cut.Find(".flare-input").ClassName);
+    }
+
+    [Fact]
+    public void FullWidthFalse_AddsAutoClass()
+    {
+        var cut = Render<FlareTextField>(p => p.Add(x => x.FullWidth, false));
+
+        Assert.Contains("flare-input--auto", cut.Find(".flare-input").ClassName);
+    }
+
+    [Fact]
+    public void FullWidthTrue_IsDefault_NoAutoClass()
+    {
+        var cut = Render<FlareTextField>();
+
+        Assert.DoesNotContain("flare-input--auto", cut.Find(".flare-input").ClassName);
+    }
+
+    [Fact]
+    public void MarginDense_AddsMarginClass()
+    {
+        var cut = Render<FlareTextField>(p => p.Add(x => x.Margin, FieldMargin.Dense));
+
+        Assert.Contains("flare-input--margin-dense", cut.Find(".flare-input").ClassName);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareCard numeric Elevation
+// ------------------------------------------------------------------------------
+public class C_FlareCardElevationTests : FlareTestContext
+{
+    [Fact]
+    public void Elevation_EmitsInlineBoxShadow()
+    {
+        var cut = Render<FlareCard>(p => p.Add(x => x.Elevation, 3));
+
+        Assert.Contains("box-shadow:var(--flare-elevation-3)", cut.Find(".flare-card").GetAttribute("style"));
+    }
+
+    [Fact]
+    public void ElevationZero_IsFlat()
+    {
+        var cut = Render<FlareCard>(p => p.Add(x => x.Elevation, 0));
+
+        Assert.Contains("box-shadow:var(--flare-elevation-0)", cut.Find(".flare-card").GetAttribute("style"));
+    }
+
+    [Fact]
+    public void Elevation_ClampedToScale()
+    {
+        var cut = Render<FlareCard>(p => p.Add(x => x.Elevation, 99));
+
+        Assert.Contains("box-shadow:var(--flare-elevation-5)", cut.Find(".flare-card").GetAttribute("style"));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareStack StretchItems / StretchFirst
+// ------------------------------------------------------------------------------
+public class C_FlareStackStretchTests : FlareTestContext
+{
+    [Fact]
+    public void StretchItems_AddsStretchClass()
+    {
+        var cut = Render<FlareStack>(p => p.Add(x => x.StretchItems, true));
+
+        Assert.Contains("flare-stack--stretch", cut.Find(".flare-stack").ClassName);
+    }
+
+    [Fact]
+    public void StretchFirst_AddsStretchFirstClass()
+    {
+        var cut = Render<FlareStack>(p => p.Add(x => x.StretchFirst, true));
+
+        Assert.Contains("flare-stack--stretch-first", cut.Find(".flare-stack").ClassName);
+    }
+
+    [Fact]
+    public void StretchItems_WinsOverStretchFirst()
+    {
+        var cut = Render<FlareStack>(p => p
+            .Add(x => x.StretchItems, true)
+            .Add(x => x.StretchFirst, true));
+
+        var cls = cut.Find(".flare-stack").ClassName;
+        Assert.Contains("flare-stack--stretch ", cls + " ");
+        Assert.DoesNotContain("flare-stack--stretch-first", cls);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareMenuItem Target + IconColor
+// ------------------------------------------------------------------------------
+public class C_FlareMenuItemTargetColorTests : FlareTestContext
+{
+    private static RenderFragment Activator => b => b.AddMarkupContent(0, "<button>Open</button>");
+
+    [Fact]
+    public void Target_Blank_AddsTargetAndRel()
+    {
+        var cut = Render<FlareMenu>(p => p
+            .Add(x => x.Activator, Activator)
+            .AddChildContent<FlareMenuItem>(mi => mi
+                .Add(x => x.Href, "https://example.com")
+                .Add(x => x.Target, "_blank")
+                .AddChildContent("External")));
+
+        cut.Find(".flare-menu__activator").Click();
+
+        var anchor = cut.Find("a.flare-menu-item");
+        Assert.Equal("_blank", anchor.GetAttribute("target"));
+        Assert.Equal("noopener noreferrer", anchor.GetAttribute("rel"));
+    }
+
+    [Fact]
+    public void IconColor_AddsColorClassOnIcon()
+    {
+        var cut = Render<FlareMenu>(p => p
+            .Add(x => x.Activator, Activator)
+            .AddChildContent<FlareMenuItem>(mi => mi
+                .Add(x => x.Icon, "edit")
+                .Add(x => x.IconColor, FlareColor.Primary)
+                .AddChildContent("Edit")));
+
+        cut.Find(".flare-menu__activator").Click();
+
+        Assert.Contains("flare-color-primary", cut.Find(".flare-menu-item__icon").ClassName);
+    }
+
+    [Fact]
+    public void LeadingIconColor_OverridesIconColor()
+    {
+        var cut = Render<FlareMenu>(p => p
+            .Add(x => x.Activator, Activator)
+            .AddChildContent<FlareMenuItem>(mi => mi
+                .Add(x => x.Icon, "edit")
+                .Add(x => x.IconColor, FlareColor.Primary)
+                .Add(x => x.LeadingIconColor, FlareColor.Error)
+                .AddChildContent("Edit")));
+
+        cut.Find(".flare-menu__activator").Click();
+
+        var cls = cut.Find(".flare-menu-item__icon").ClassName;
+        Assert.Contains("flare-color-error", cls);
+        Assert.DoesNotContain("flare-color-primary", cls);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareToggleGroup cascade (Size / Color / Disabled)
+// ------------------------------------------------------------------------------
+public class C_FlareToggleGroupCascadeTests : FlareTestContext
+{
+    [Fact]
+    public void GroupSize_CascadesToButtons()
+    {
+        var cut = Render<FlareToggleGroup<string>>(p => p
+            .Add(x => x.Size, ButtonSize.Lg)
+            .AddChildContent<FlareToggleButton>(b => b
+                .Add(x => x.Value, (object?)"a")
+                .AddChildContent("A")));
+
+        Assert.Contains("flare-toggle-btn--lg", cut.Find("button.flare-toggle-btn").ClassName);
+    }
+
+    [Fact]
+    public void GroupColor_CascadesColorClassToButtons()
+    {
+        var cut = Render<FlareToggleGroup<string>>(p => p
+            .Add(x => x.Color, FlareColor.Tertiary)
+            .AddChildContent<FlareToggleButton>(b => b
+                .Add(x => x.Value, (object?)"a")
+                .AddChildContent("A")));
+
+        Assert.Contains("flare-color-tertiary", cut.Find("button.flare-toggle-btn").ClassName);
+    }
+
+    [Fact]
+    public void GroupDisabled_DisablesButtons()
+    {
+        var cut = Render<FlareToggleGroup<string>>(p => p
+            .Add(x => x.Disabled, true)
+            .AddChildContent<FlareToggleButton>(b => b
+                .Add(x => x.Value, (object?)"a")
+                .AddChildContent("A")));
+
+        Assert.True(cut.Find("button.flare-toggle-btn").HasAttribute("disabled"));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareSelect declarative <option> child content
+// ------------------------------------------------------------------------------
+public class C_FlareSelectDeclarativeTests : FlareTestContext
+{
+    private static RenderFragment Options => b =>
+    {
+        b.OpenElement(0, "option");
+        b.AddAttribute(1, "value", "a");
+        b.AddContent(2, "Apple");
+        b.CloseElement();
+        b.OpenElement(3, "option");
+        b.AddAttribute(4, "value", "b");
+        b.AddContent(5, "Banana");
+        b.CloseElement();
+    };
+
+    [Fact]
+    public void DeclarativeOptions_RenderInDropdown()
+    {
+        var cut = Render<FlareSelect<string>>(p => p.Add(x => x.ChildContent, Options));
+
+        cut.Find(".flare-select__control").Click();
+
+        Assert.Equal(2, cut.FindAll(".flare-select__option").Count);
+    }
+
+    [Fact]
+    public void DeclarativeOptions_SelectedLabelShown()
+    {
+        var cut = Render<FlareSelect<string>>(p => p
+            .Add(x => x.Value, "b")
+            .Add(x => x.ChildContent, Options));
+
+        Assert.Contains("Banana", cut.Find(".flare-select__value").TextContent);
+    }
+
+    // Static <option> markup is compiled by Razor into a single Markup frame (raw HTML), not element
+    // frames - bUnit's AddChildContent(string) reproduces that shape, which the parser must handle.
+    [Fact]
+    public void StaticOptionMarkup_RendersOptions()
+    {
+        var cut = Render<FlareSelect<string>>(p => p.AddChildContent(
+            "<option value=\"a\">Apple</option><option value=\"b\">Banana</option><option value=\"c\">Cherry</option>"));
+
+        cut.Find(".flare-select__control").Click();
+
+        Assert.Equal(3, cut.FindAll(".flare-select__option").Count);
+    }
+
+    [Fact]
+    public void StaticOptionMarkup_SelectedLabelShown()
+    {
+        var cut = Render<FlareSelect<string>>(p => p
+            .Add(x => x.Value, "b")
+            .AddChildContent("<option value=\"a\">Apple</option><option value=\"b\">Banana</option>"));
+
+        Assert.Contains("Banana", cut.Find(".flare-select__value").TextContent);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareLink Typo
+// ------------------------------------------------------------------------------
+public class C_FlareLinkTypoTests : FlareTestContext
+{
+    [Fact]
+    public void Typo_AddsTypeScaleClass()
+    {
+        var cut = Render<FlareLink>(p => p
+            .Add(x => x.Href, "#")
+            .Add(x => x.Typo, TypographyScale.TitleMedium)
+            .AddChildContent("Link"));
+
+        Assert.Contains("flare-text--title-medium", cut.Find("a").ClassName);
+    }
+
+    [Fact]
+    public void NoTypo_NoTypeScaleClass()
+    {
+        var cut = Render<FlareLink>(p => p
+            .Add(x => x.Href, "#")
+            .AddChildContent("Link"));
+
+        Assert.DoesNotContain("flare-text--", cut.Find("a").ClassName);
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareCollapse (standalone expand/collapse)
+// ------------------------------------------------------------------------------
+public class C_FlareCollapseTests : FlareTestContext
+{
+    [Fact]
+    public void Collapsed_ByDefault()
+    {
+        var cut = Render<FlareCollapse>(p => p
+            .AddChildContent("<p class=\"inner\">Body</p>"));
+
+        Assert.DoesNotContain("flare-collapse--expanded", cut.Find(".flare-collapse").ClassName);
+    }
+
+    [Fact]
+    public void Expanded_AddsExpandedClass()
+    {
+        var cut = Render<FlareCollapse>(p => p
+            .Add(x => x.Expanded, true)
+            .AddChildContent("<p class=\"inner\">Body</p>"));
+
+        Assert.Contains("flare-collapse--expanded", cut.Find(".flare-collapse").ClassName);
+    }
+
+    [Fact]
+    public void Header_RendersToggleButton_AndExpands()
+    {
+        var cut = Render<FlareCollapse>(p => p
+            .Add(x => x.Header, "More")
+            .AddChildContent("<p class=\"inner\">Body</p>"));
+
+        var btn = cut.Find("button.flare-collapse__header");
+        Assert.Equal("false", btn.GetAttribute("aria-expanded"));
+
+        btn.Click();
+
+        Assert.Contains("flare-collapse--expanded", cut.Find(".flare-collapse").ClassName);
+        Assert.Equal("true", cut.Find("button.flare-collapse__header").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void Headerless_RendersNoToggleButton()
+    {
+        var cut = Render<FlareCollapse>(p => p
+            .AddChildContent("<p class=\"inner\">Body</p>"));
+
+        Assert.Empty(cut.FindAll("button.flare-collapse__header"));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// ISnackbarService options overload
+// ------------------------------------------------------------------------------
+public class C_SnackbarOptionsTests
+{
+    [Fact]
+    public void Show_WithOptions_MapsAllFields()
+    {
+        var service = new SnackbarService();
+        SnackbarMessage? captured = null;
+        service.OnShow += m => captured = m;
+
+        service.Show("Saved", new SnackbarOptions
+        {
+            Severity = SnackbarSeverity.Warning,
+            DurationMs = 0,
+            ShowClose = false,
+            ShowProgress = true,
+            CssClass = "my-snackbar",
+            CloseAfterNavigation = true,
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal("Saved", captured!.Text);
+        Assert.Equal(SnackbarSeverity.Warning, captured.Severity);
+        Assert.Equal(0, captured.DurationMs);
+        Assert.False(captured.ShowClose);
+        Assert.True(captured.ShowProgress);
+        Assert.Equal("my-snackbar", captured.CssClass);
+        Assert.True(captured.CloseAfterNavigation);
+    }
+
+    [Fact]
+    public void Show_WithNullOptions_Throws()
+    {
+        var service = new SnackbarService();
+
+        Assert.Throws<ArgumentNullException>(() => service.Show("x", (SnackbarOptions)null!));
+    }
+}
+
+// ------------------------------------------------------------------------------
+// FlareSnackbarProvider per-message CssClass + CloseAfterNavigation
+// ------------------------------------------------------------------------------
+public class C_SnackbarProviderOptionsTests : FlareTestContext
+{
+    public C_SnackbarProviderOptionsTests()
+    {
+        Services.AddSingleton<ISnackbarService, SnackbarService>();
+    }
+
+    [Fact]
+    public void CssClass_AppliedToSnackbarElement()
+    {
+        var cut = Render<FlareSnackbarProvider>();
+        var service = Services.GetRequiredService<ISnackbarService>();
+
+        service.Show("Hi", new SnackbarOptions { DurationMs = 0, CssClass = "promo-snackbar" });
+        cut.WaitForState(() => cut.FindAll(".flare-snackbar").Count > 0);
+
+        Assert.NotEmpty(cut.FindAll(".promo-snackbar"));
+    }
+
+    [Fact]
+    public void CloseAfterNavigation_DismissesOnNavigate()
+    {
+        var cut = Render<FlareSnackbarProvider>();
+        var service = Services.GetRequiredService<ISnackbarService>();
+        var nav = Services.GetRequiredService<NavigationManager>();
+
+        service.Show("Hi", new SnackbarOptions { DurationMs = 0, CloseAfterNavigation = true });
+        cut.WaitForState(() => cut.FindAll(".flare-snackbar").Count > 0);
+
+        nav.NavigateTo("/other");
+
+        cut.WaitForState(() => cut.FindAll(".flare-snackbar").Count == 0);
+        Assert.Empty(cut.FindAll(".flare-snackbar"));
+    }
+}


### PR DESCRIPTION
Additive, backward-compatible API additions surfaced while migrating a real app from MudBlazor to Flare. Each ships with XML docs, a Gallery demo (EN+RU localized) and tests.

- FlareIconButton: dedicated icon-only button (wrapper over FlareButton)
- FlareCollapse: standalone expand/collapse container (new page)
- FlareChip.Variant (Outlined/Filled/Elevated)
- FlareAvatar.FallbackIcon / FallbackContent
- FlareField.Error/Invalid (state without a message), FullWidth, Margin
- FlareStack.StretchItems / StretchFirst
- FlareMenuItem.Target + IconColor/LeadingIconColor
- FlareToggleGroup cascades Size/Color/Disabled; FlareToggleButton.Color
- FlareCard.Elevation (numeric 0-5; 0 == flat)
- FlareSelect: declarative native <option> child content (fixes the existing option-based Gallery demos, which previously rendered empty)
- ISnackbarService.Show(string, SnackbarOptions): per-message styling + CloseAfterNavigation; SnackbarMessage gains CssClass/CloseAfterNavigation
- FlareLink.Typo
- FlareHidden Only+Invert band visibility demonstrated on the Responsive page

Build clean; 1254 component tests + 64 core tests pass.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
