### PR TITLE
Fix: breakpoint detection no longer latches to Xs on an invalid width…

### DIFF
--- a/src/Flare.Components/wwwroot/js/flare-ui.js
+++ b/src/Flare.Components/wwwroot/js/flare-ui.js
@@ -34,13 +34,35 @@ export function scrollToTop(selector) {
 // Boundaries mirror responsive.css: xs<600, sm>=600, md>=960, lg>=1280, xl>=1920.
 const _bpListeners = new Map();
 
-function currentBreakpoint() {
+// window.innerWidth can read as 0 (or otherwise be unavailable) during an unsettled/very-early
+// paint moment -- e.g. right after navigation, before the viewport is fully established in some
+// embedding contexts. A width of 0 falls through every >= check in currentBreakpoint() and would
+// misreport 'Xs', so treat non-positive readings as invalid and fall back to
+// document.documentElement.clientWidth (generally populated even before window dimensions settle),
+// then document.body.clientWidth as a last resort. Returns null when no source yields a usable width.
+function measuredWidth() {
     const w = window.innerWidth;
+    if (w > 0) return w;
+    const docEl = document.documentElement && document.documentElement.clientWidth;
+    if (docEl > 0) return docEl;
+    const body = document.body && document.body.clientWidth;
+    if (body > 0) return body;
+    return null;
+}
+
+function widthToBreakpoint(w) {
     if (w >= 1920) return 'Xl';
     if (w >= 1280) return 'Lg';
     if (w >= 960)  return 'Md';
     if (w >= 600)  return 'Sm';
     return 'Xs';
+}
+
+function currentBreakpoint() {
+    const w = measuredWidth();
+    // No reliable width source at all: default to Md rather than confidently reporting the
+    // narrowest tier off a bogus 0 reading.
+    return w === null ? 'Md' : widthToBreakpoint(w);
 }
 
 export function getBreakpoint() {
@@ -51,7 +73,11 @@ export function subscribeBreakpoint(id, dotNetRef) {
     unsubscribeBreakpoint(id);
     let last = currentBreakpoint();
     const handler = () => {
-        const bp = currentBreakpoint();
+        // Skip entirely on a spurious resize event where the width is unmeasurable -- don't let a
+        // transient invalid reading overwrite `last` or notify C# of a bogus breakpoint.
+        const w = measuredWidth();
+        if (w === null) return;
+        const bp = widthToBreakpoint(w);
         if (bp !== last) {
             last = bp;
             dotNetRef.invokeMethodAsync('OnBreakpointChanged', bp);


### PR DESCRIPTION
… reading

window.innerWidth can read 0 during an unsettled/very-early paint moment (e.g. right after navigation, before the viewport is established in some embedding contexts), which fell through every threshold check and confidently reported Xs. Since the breakpoint is only re-evaluated on a later resize event, a bad initial reading stuck FlareLayout in permanent mobile mode. currentBreakpoint() now falls back to document.documentElement.clientWidth, then document.body.clientWidth, before giving up; subscribeBreakpoint's resize handler also skips updating state entirely when a fresh reading is itself unmeasurable, so a later spurious resize can't latch onto a bad value either.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
