### PR TITLE
Fix: reference Shape.Full for button corner radii instead of hardcode…

### DIFF
--- a/src/Flare.Abstractions/Tokens/Components/ButtonTokens.cs
+++ b/src/Flare.Abstractions/Tokens/Components/ButtonTokens.cs
@@ -25,16 +25,21 @@ public sealed record ButtonTokens
 
     // --- 2. ПОУГЛОВЫЕ РАДИУСЫ ПОД КАЖДЫЙ ИЗ 5 РАЗМЕРОВ ---
     // (compound: each expands to 4 per-corner --flare-btn-radius-* vars in CssVarMap.FlattenDesign)
+    // All 5 sizes are fully-rounded pills (radius == half of the fixed container height for every
+    // size), so they reference the Shape.Full scale token - like every other component that follows
+    // the shape scale - instead of a hardcoded half-height rem literal. This preserves the pill visual
+    // (border-radius: 9999px renders identically to an explicit half-height on these fixed heights)
+    // while giving theme authors the standard Shape.Full override hook for button rounding.
     /// <summary>Radius xs token.</summary>
-    public CornerRadiusTokens RadiusXs { get; init; } = CornerRadiusTokens.All("1rem");     // 32px / 2 = 16px
+    public CornerRadiusTokens RadiusXs { get; init; } = CornerRadiusTokens.All(Vars.Var(Shape.Full));
     /// <summary>Radius sm token.</summary>
-    public CornerRadiusTokens RadiusSm { get; init; } = CornerRadiusTokens.All("1.25rem");  // 40px / 2 = 20px
+    public CornerRadiusTokens RadiusSm { get; init; } = CornerRadiusTokens.All(Vars.Var(Shape.Full));
     /// <summary>Radius md token.</summary>
-    public CornerRadiusTokens RadiusMd { get; init; } = CornerRadiusTokens.All("1.5rem");   // 48px / 2 = 24px
+    public CornerRadiusTokens RadiusMd { get; init; } = CornerRadiusTokens.All(Vars.Var(Shape.Full));
     /// <summary>Radius lg token.</summary>
-    public CornerRadiusTokens RadiusLg { get; init; } = CornerRadiusTokens.All("1.75rem");  // 56px / 2 = 28px
+    public CornerRadiusTokens RadiusLg { get; init; } = CornerRadiusTokens.All(Vars.Var(Shape.Full));
     /// <summary>Radius xl token.</summary>
-    public CornerRadiusTokens RadiusXl { get; init; } = CornerRadiusTokens.All("2rem");     // 64px / 2 = 32px
+    public CornerRadiusTokens RadiusXl { get; init; } = CornerRadiusTokens.All(Vars.Var(Shape.Full));
 
     // --- 3. ВЫСОТА КОНТЕЙНЕРОВ (Container Heights) ---
     /// <summary>Height xs token (<c>2rem</c>).</summary>

--- a/src/Flare.Theme.MaterialDesign3Expressive/MaterialDesignTokens.cs
+++ b/src/Flare.Theme.MaterialDesign3Expressive/MaterialDesignTokens.cs
@@ -117,12 +117,13 @@ internal class MaterialDesignTokens
         PaddingInlineLg = "2rem",
         PaddingInlineXl = "2.5rem",
 
-        // Поугловые радиусы (высота контейнера / 2) для создания идеальных капсул
-        RadiusXs = CornerRadiusTokens.All("1rem"),
-        RadiusSm = CornerRadiusTokens.All("1.25rem"),
-        RadiusMd = CornerRadiusTokens.All("1.5rem"),
-        RadiusLg = CornerRadiusTokens.All("1.75rem"),
-        RadiusXl = CornerRadiusTokens.All("2rem"),
+        // Поугловые радиусы: полностью скруглённая капсула на всех 5 размерах, поэтому ссылаемся
+        // на шкалу Shape.Full (как и остальные компоненты), а не на захардкоженный half-height rem.
+        RadiusXs = CornerRadiusTokens.All("var(--flare-shape-full)"),
+        RadiusSm = CornerRadiusTokens.All("var(--flare-shape-full)"),
+        RadiusMd = CornerRadiusTokens.All("var(--flare-shape-full)"),
+        RadiusLg = CornerRadiusTokens.All("var(--flare-shape-full)"),
+        RadiusXl = CornerRadiusTokens.All("var(--flare-shape-full)"),
 
         // Настройки обводки фокуса и теней
         FocusOutline = "3px solid var(--flare-color-primary)",


### PR DESCRIPTION
…d rem literals

ButtonTokens.RadiusXs/Sm/Md/Lg/Xl previously hardcoded a half-height rem value per size (e.g. RadiusMd = 1.5rem for HeightMd = 3rem), unlike every other component (Card, Input, Chip, Switch, Drawer, Nav) which references the Shape scale via a var(--flare-shape-*) token. All five radii are exactly half their button's fixed height, i.e. a full pill for that height, so they now reference Shape.Full - preserving the identical pill visual (9999px renders the same as an explicit half-height on these fixed heights) while giving theme authors the standard Shape.Full override hook for button rounding.

MaterialDesign3Expressive explicitly duplicated the same literal values (rather than inheriting the shared default), so its override is updated to var(--flare-shape-full) too; MaterialDesign3 baseline inherits this via its Button = reference.Button with { ... } derivation. Aero, FluentUI2, LiquidGlass, MaterialDesign2 and VisualStudio all already override every RadiusXx explicitly (non-pill corners for Aero/FluentUI2/MaterialDesign2/ VisualStudio, already Shape.Full for LiquidGlass), so they are unaffected by the shared default change.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
