### PR TITLE
Feat: add mobile bottom-navigation component (FlareBottomNav)

### DIFF
--- a/samples/Flare.Gallery/Models/ComponentCatalog.cs
+++ b/samples/Flare.Gallery/Models/ComponentCatalog.cs
@@ -136,6 +136,7 @@ public static class ComponentCatalog
         new ComponentEntry("/components/stack",             "Stack",                   "Stack_Title",           ComponentGroup.Layout),
 
         // -- Navigation -----------------------------------------------------------
+        new ComponentEntry("/components/bottomnav",         "Bottom Nav",              "BottomNav_Title",       ComponentGroup.Navigation),
         new ComponentEntry("/components/breadcrumb",        "Breadcrumb",              "Breadcrumb_Title",      ComponentGroup.Navigation),
         new ComponentEntry("/components/drawer",            "Drawer",                  "Drawer_Title",          ComponentGroup.Navigation),
         new ComponentEntry("/components/link",              "Link",                    "Link_Title",            ComponentGroup.Navigation),

--- a/samples/Flare.Gallery/Pages/Components/BottomNav/BottomNavPage.razor
+++ b/samples/Flare.Gallery/Pages/Components/BottomNav/BottomNavPage.razor
@@ -1,0 +1,12 @@
+@page "/components/bottomnav"
+@inherits LocalizedPage
+
+<PageTitle>@GalleryStrings.BottomNav_Title - Flare</PageTitle>
+
+<GalleryPageTitle Api="FlareBottomNav">
+    <FlareText Typo="TypographyScale.HeadlineMedium">@GalleryStrings.BottomNav_Title</FlareText>
+    <FlareText Color="FlareColor.OnSurfaceVariant" Typo="TypographyScale.BodyLarge">@GalleryStrings.BottomNav_Subtitle</FlareText>
+</GalleryPageTitle>
+
+<AutoDemoSection Title="@GalleryStrings.BottomNav_Basic" DemoType="typeof(Examples.BottomNavBasicDemo)" />
+<AutoDemoSection Title="@GalleryStrings.BottomNav_Disabled" DemoType="typeof(Examples.BottomNavDisabledDemo)" />

--- a/samples/Flare.Gallery/Pages/Components/BottomNav/Examples/BottomNavBasicDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/BottomNav/Examples/BottomNavBasicDemo.razor
@@ -1,0 +1,24 @@
+@* FlareBottomNav lays out its FlareBottomNavItem children with equal flex distribution. The
+   component itself does not set position:fixed - here it just sits inside a bordered card so the
+   demo does not take over the whole page; in a real layout you would pin it to the viewport bottom
+   from your own CSS. *@
+<FlareCard Variant="CardVariant.Filled" Style="max-width:360px;padding:0;overflow:hidden;border-radius:var(--flare-shape-medium);">
+    <FlareBottomNav>
+        <FlareBottomNavItem Href="/" Match="NavMatchMode.Exact">
+            <Icon><FlareIcon Name="home" /></Icon>
+            <ChildContent>Home</ChildContent>
+        </FlareBottomNavItem>
+        <FlareBottomNavItem Href="#search">
+            <Icon><FlareIcon Name="search" /></Icon>
+            <ChildContent>Search</ChildContent>
+        </FlareBottomNavItem>
+        <FlareBottomNavItem Href="#favorites" Active="true">
+            <Icon><FlareIcon Name="favorite" /></Icon>
+            <ChildContent>Favorites</ChildContent>
+        </FlareBottomNavItem>
+        <FlareBottomNavItem Href="#profile">
+            <Icon><FlareIcon Name="person" /></Icon>
+            <ChildContent>Profile</ChildContent>
+        </FlareBottomNavItem>
+    </FlareBottomNav>
+</FlareCard>

--- a/samples/Flare.Gallery/Pages/Components/BottomNav/Examples/BottomNavDisabledDemo.razor
+++ b/samples/Flare.Gallery/Pages/Components/BottomNav/Examples/BottomNavDisabledDemo.razor
@@ -1,0 +1,23 @@
+@* Disabled items stay in place (equal flex distribution is preserved) but ignore clicks and dim to
+   the theme's disabled-state opacity. AriaLabel overrides the default "Bottom navigation" landmark
+   label. *@
+<FlareCard Variant="CardVariant.Filled" Style="max-width:360px;padding:0;overflow:hidden;border-radius:var(--flare-shape-medium);">
+    <FlareBottomNav AriaLabel="Store sections">
+        <FlareBottomNavItem Href="/" Match="NavMatchMode.Exact">
+            <Icon><FlareIcon Name="storefront" /></Icon>
+            <ChildContent>Shop</ChildContent>
+        </FlareBottomNavItem>
+        <FlareBottomNavItem Href="#cart" Active="true">
+            <Icon><FlareIcon Name="shopping_cart" /></Icon>
+            <ChildContent>Cart</ChildContent>
+        </FlareBottomNavItem>
+        <FlareBottomNavItem Href="#offers" Disabled="true" Tooltip="Coming soon">
+            <Icon><FlareIcon Name="local_offer" /></Icon>
+            <ChildContent>Offers</ChildContent>
+        </FlareBottomNavItem>
+        <FlareBottomNavItem Href="#account">
+            <Icon><FlareIcon Name="account_circle" /></Icon>
+            <ChildContent>Account</ChildContent>
+        </FlareBottomNavItem>
+    </FlareBottomNav>
+</FlareCard>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.Designer.cs
@@ -1000,7 +1000,43 @@ namespace Flare.Gallery.Resources {
                 return ResourceManager.GetString("Badge_Title", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Basic bottom navigation.
+        /// </summary>
+        public static string BottomNav_Basic {
+            get {
+                return ResourceManager.GetString("BottomNav_Basic", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Disabled item &amp; custom aria-label.
+        /// </summary>
+        public static string BottomNav_Disabled {
+            get {
+                return ResourceManager.GetString("BottomNav_Disabled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на FlareBottomNav, FlareBottomNavItem - mobile bottom navigation bar..
+        /// </summary>
+        public static string BottomNav_Subtitle {
+            get {
+                return ResourceManager.GetString("BottomNav_Subtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Bottom Nav.
+        /// </summary>
+        public static string BottomNav_Title {
+            get {
+                return ResourceManager.GetString("BottomNav_Title", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Items.
         /// </summary>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.resx
@@ -318,6 +318,18 @@
   <data name="Chip_SizeColor" xml:space="preserve">
     <value>Sizes, colors &amp; click</value>
   </data>
+  <data name="BottomNav_Title" xml:space="preserve">
+    <value>Bottom Nav</value>
+  </data>
+  <data name="BottomNav_Subtitle" xml:space="preserve">
+    <value>FlareBottomNav, FlareBottomNavItem - mobile bottom navigation bar.</value>
+  </data>
+  <data name="BottomNav_Basic" xml:space="preserve">
+    <value>Basic bottom navigation</value>
+  </data>
+  <data name="BottomNav_Disabled" xml:space="preserve">
+    <value>Disabled item &amp; custom aria-label</value>
+  </data>
   <data name="Breadcrumb_Title" xml:space="preserve">
     <value>Breadcrumb</value>
   </data>

--- a/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
+++ b/samples/Flare.Gallery/Resources/GalleryStrings.ru.resx
@@ -318,6 +318,18 @@
   <data name="Chip_SizeColor" xml:space="preserve">
     <value>Размеры, цвета и клик</value>
   </data>
+  <data name="BottomNav_Title" xml:space="preserve">
+    <value>Нижняя навигация</value>
+  </data>
+  <data name="BottomNav_Subtitle" xml:space="preserve">
+    <value>FlareBottomNav, FlareBottomNavItem - панель нижней навигации для мобильных интерфейсов.</value>
+  </data>
+  <data name="BottomNav_Basic" xml:space="preserve">
+    <value>Базовая нижняя навигация</value>
+  </data>
+  <data name="BottomNav_Disabled" xml:space="preserve">
+    <value>Отключённый элемент и своя aria-label</value>
+  </data>
   <data name="Breadcrumb_Title" xml:space="preserve">
     <value>Хлебные крошки</value>
   </data>

--- a/src/Flare.Abstractions/Css/Classes/BottomNav.cs
+++ b/src/Flare.Abstractions/Css/Classes/BottomNav.cs
@@ -1,0 +1,21 @@
+namespace Flare.Css.Classes;
+
+/// <summary>CSS classes for the mobile bottom-navigation bar (<c>FlareBottomNav</c> / <c>FlareBottomNavItem</c>).</summary>
+public static class BottomNav
+{
+    /// <summary>The <c>flare-bottom-nav</c> CSS class.</summary>
+    public const string Root = "flare-bottom-nav";
+    /// <summary>The <c>flare-bottom-nav-item</c> CSS class.</summary>
+    public const string Item = "flare-bottom-nav-item";
+    /// <summary>The <c>flare-bottom-nav-item--active</c> CSS class.</summary>
+    public const string ItemActive = "flare-bottom-nav-item--active";
+    /// <summary>The <c>flare-bottom-nav-item--disabled</c> CSS class.</summary>
+    public const string ItemDisabled = "flare-bottom-nav-item--disabled";
+    /// <summary>The <c>flare-bottom-nav-item__icon</c> CSS class.</summary>
+    public const string ItemIcon = "flare-bottom-nav-item__icon";
+    /// <summary>The <c>flare-bottom-nav-item__indicator</c> CSS class: the pill-shaped active-state
+    /// background drawn behind the icon.</summary>
+    public const string ItemIndicator = "flare-bottom-nav-item__indicator";
+    /// <summary>The <c>flare-bottom-nav-item__label</c> CSS class.</summary>
+    public const string ItemLabel = "flare-bottom-nav-item__label";
+}

--- a/src/Flare.Abstractions/Css/Tokens/BottomNavTokens.cs
+++ b/src/Flare.Abstractions/Css/Tokens/BottomNavTokens.cs
@@ -1,0 +1,32 @@
+namespace Flare.Css.Tokens;
+
+/// <summary>CSS variable tokens for the mobile bottom-navigation bar.</summary>
+public static class BottomNavField
+{
+    private const string Prefix = $"{Vars.Flare}-bottom-nav";
+
+    /// <summary>CSS custom-property name for the bar height token.</summary>
+    public const string BarHeight = $"{Prefix}-bar-height";
+    /// <summary>CSS custom-property name for the bar background token.</summary>
+    public const string BarBg = $"{Prefix}-bar-bg";
+    /// <summary>CSS custom-property name for the bar top-border color token.</summary>
+    public const string BorderColor = $"{Prefix}-border-color";
+    /// <summary>CSS custom-property name for the safe-area-aware bottom padding token.</summary>
+    public const string SafeAreaPadding = $"{Prefix}-safe-area-padding";
+    /// <summary>CSS custom-property name for the inactive item color token.</summary>
+    public const string InactiveColor = $"{Prefix}-inactive-color";
+    /// <summary>CSS custom-property name for the active item color token.</summary>
+    public const string ActiveColor = $"{Prefix}-active-color";
+    /// <summary>CSS custom-property name for the icon size token.</summary>
+    public const string IconSize = $"{Prefix}-icon-size";
+    /// <summary>CSS custom-property name for the label font size token.</summary>
+    public const string LabelFontSize = $"{Prefix}-label-font-size";
+    /// <summary>CSS custom-property name for the label font weight token.</summary>
+    public const string LabelFontWeight = $"{Prefix}-label-font-weight";
+    /// <summary>CSS custom-property name for the active label font weight token.</summary>
+    public const string LabelFontWeightActive = $"{Prefix}-label-font-weight-active";
+    /// <summary>CSS custom-property name for the active-item indicator pill background token.</summary>
+    public const string IndicatorBg = $"{Prefix}-indicator-bg";
+    /// <summary>CSS custom-property name for the active-item indicator pill corner-radius token.</summary>
+    public const string IndicatorRadius = $"{Prefix}-indicator-radius";
+}

--- a/src/Flare.Abstractions/Tokens/Components/BottomNavTokens.cs
+++ b/src/Flare.Abstractions/Tokens/Components/BottomNavTokens.cs
@@ -1,0 +1,50 @@
+using Flare.Css;
+using Flare.Css.Tokens;
+namespace Flare.Abstractions.Tokens.Components;
+
+/// <summary>
+/// Per-theme tokens for the mobile bottom-navigation bar (<c>FlareBottomNav</c> / <c>FlareBottomNavItem</c>).
+/// Defaults follow Material Design 3 (surface-container bar with a secondary-container active pill);
+/// other themes may override individual fields (e.g. a flatter bar or an accent-bar active state).
+/// </summary>
+public sealed record BottomNavTokens
+{
+    /// <summary>Fixed height of the bar (excluding safe-area padding). MD3 = 80dp.</summary>
+    [CssVar(BottomNavField.BarHeight)] public string BarHeight { get; init; } = "5rem";
+
+    /// <summary>Bar background. MD3 = surface-container.</summary>
+    [CssVar(BottomNavField.BarBg)] public string BarBg { get; init; } = Vars.Var(Color.SurfaceContainer);
+
+    /// <summary>Top border color separating the bar from page content. MD3 = surface-variant.</summary>
+    [CssVar(BottomNavField.BorderColor)] public string BorderColor { get; init; } = Vars.Var(Color.SurfaceVariant);
+
+    /// <summary>
+    /// Extra bottom padding reserved for the device safe area (iOS home indicator, gesture bar),
+    /// stacked on top of <see cref="BarHeight"/> via <c>env(safe-area-inset-bottom)</c>.
+    /// </summary>
+    [CssVar(BottomNavField.SafeAreaPadding)] public string SafeAreaPadding { get; init; } = "env(safe-area-inset-bottom, 0px)";
+
+    /// <summary>Icon + label color for an inactive item. MD3 = on-surface-variant.</summary>
+    [CssVar(BottomNavField.InactiveColor)] public string InactiveColor { get; init; } = Vars.Var(Color.OnSurfaceVariant);
+
+    /// <summary>Icon + label color for the active item. MD3 = on-secondary-container (sits atop the pill).</summary>
+    [CssVar(BottomNavField.ActiveColor)] public string ActiveColor { get; init; } = Vars.Var(Color.OnSecondaryContainer);
+
+    /// <summary>Icon glyph size.</summary>
+    [CssVar(BottomNavField.IconSize)] public string IconSize { get; init; } = "1.5rem";
+
+    /// <summary>Label font size. MD3 = label-medium.</summary>
+    [CssVar(BottomNavField.LabelFontSize)] public string LabelFontSize { get; init; } = Vars.Var(Typography.Size("label-medium"));
+
+    /// <summary>Inactive label font weight.</summary>
+    [CssVar(BottomNavField.LabelFontWeight)] public string LabelFontWeight { get; init; } = "500";
+
+    /// <summary>Active label font weight (slightly heavier to reinforce the selected state).</summary>
+    [CssVar(BottomNavField.LabelFontWeightActive)] public string LabelFontWeightActive { get; init; } = "700";
+
+    /// <summary>Background of the pill drawn behind the active item's icon. MD3 = secondary-container.</summary>
+    [CssVar(BottomNavField.IndicatorBg)] public string IndicatorBg { get; init; } = Vars.Var(Color.SecondaryContainer);
+
+    /// <summary>Corner radius of the active-item indicator pill. MD3 = full.</summary>
+    [CssVar(BottomNavField.IndicatorRadius)] public string IndicatorRadius { get; init; } = Vars.Var(Shape.Full);
+}

--- a/src/Flare.Abstractions/Tokens/DesignTokens.cs
+++ b/src/Flare.Abstractions/Tokens/DesignTokens.cs
@@ -92,6 +92,9 @@ public sealed record DesignTokens
     /// <summary>Navigation (nav item + active indicator) tokens.</summary>
     public NavTokens Nav { get; init; } = new();
 
+    /// <summary>Mobile bottom-navigation bar tokens.</summary>
+    public BottomNavTokens BottomNav { get; init; } = new();
+
     /// <summary>FlareTableOfContents / FlareOnThisPage tokens.</summary>
     public TableOfContentsTokens TableOfContents { get; init; } = new();
 

--- a/src/Flare.Components/Nav/FlareBottomNav.razor
+++ b/src/Flare.Components/Nav/FlareBottomNav.razor
@@ -1,0 +1,17 @@
+@namespace Flare.Components
+@inherits FlareComponentBase
+
+<nav class="@BuildCssClass()" style="@Style" aria-label="@(string.IsNullOrEmpty(AriaLabel) ? FlareStrings.Nav_BottomNavigation : AriaLabel)" @attributes="AdditionalAttributes">
+    @ChildContent
+</nav>
+
+@code {
+    /// <summary>The <c>FlareBottomNavItem</c> entries rendered inside the bar, laid out with equal
+    /// flex distribution across the available width.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Accessible label for the navigation landmark, forwarded as <c>aria-label</c>.</summary>
+    [Parameter] public string? AriaLabel { get; set; }
+
+    protected override string ComponentCssClass => Css.Classes.BottomNav.Root;
+}

--- a/src/Flare.Components/Nav/FlareBottomNavItem.razor
+++ b/src/Flare.Components/Nav/FlareBottomNavItem.razor
@@ -1,0 +1,120 @@
+@namespace Flare.Components
+@inherits FlareComponentBase
+@inject NavigationManager Navigation
+
+<a class="@BuildCssClass(_activeClass, _disabledClass)"
+   href="@_safeHref"
+   style="@Style"
+   title="@Tooltip"
+   aria-current="@(_isActive ? "page" : null)"
+   @onclick="HandleClick"
+   @onclick:preventDefault="@(OnClick.HasDelegate)"
+   @attributes="AdditionalAttributes">
+    <span class="@Css.Classes.BottomNav.ItemIndicator">
+        <span class="@Css.Classes.BottomNav.ItemIcon">@Icon</span>
+    </span>
+    <span class="@Css.Classes.BottomNav.ItemLabel">@ChildContent</span>
+</a>
+
+@code {
+    /// <summary>URL the item navigates to.</summary>
+    [Parameter] public string? Href { get; set; }
+    /// <summary>Label content rendered under the icon.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    /// <summary>Icon rendered above the label.</summary>
+    [Parameter] public RenderFragment? Icon { get; set; }
+    /// <summary>Optional native tooltip (<c>title</c>).</summary>
+    [Parameter] public string? Tooltip { get; set; }
+    /// <summary>Route matching strategy - prefix or exact.</summary>
+    [Parameter] public NavMatchMode Match { get; set; } = NavMatchMode.Prefix;
+    /// <summary>Forces the active state regardless of current route.</summary>
+    [Parameter] public bool Active { get; set; }
+    /// <summary>Prevents navigation and interaction when true.</summary>
+    [Parameter] public bool Disabled { get; set; }
+    /// <summary>Callback fired when the item is clicked.</summary>
+    [Parameter] public EventCallback OnClick { get; set; }
+    /// <summary>Callback fired when the item's active state changes (true when it becomes active).</summary>
+    [Parameter] public EventCallback<bool> OnActiveChanged { get; set; }
+
+    protected override string ComponentCssClass => Css.Classes.BottomNav.Item;
+
+    private bool _wasActive;
+
+    private static bool IsHrefSafe(string? href) =>
+        href is null || href.StartsWith('/') || href.StartsWith('#') ||
+        href.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+        href.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+        href.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ||
+        href.StartsWith("tel:", StringComparison.OrdinalIgnoreCase);
+
+    private string _safeHref => IsHrefSafe(Href) ? (Href ?? string.Empty) : "about:blank";
+
+    private bool _isActive => Active || (Href is not null && IsHrefActive());
+    private string _activeClass => _isActive ? Css.Classes.BottomNav.ItemActive : string.Empty;
+    private string _disabledClass => Disabled ? Css.Classes.BottomNav.ItemDisabled : string.Empty;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        Navigation.LocationChanged += OnLocationChanged;
+    }
+
+    // Runs on first render and on every parameter change (e.g. Active toggled) so the initial
+    // active state is captured even when the page deep-links straight into this item.
+    protected override Task OnParametersSetAsync() => SyncActiveAsync();
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+        => InvokeAsync(async () =>
+        {
+            await SyncActiveAsync();
+            StateHasChanged();
+        });
+
+    private async Task SyncActiveAsync()
+    {
+        var active = _isActive;
+        if (active == _wasActive) return;
+        _wasActive = active;
+        if (OnActiveChanged.HasDelegate)
+            await OnActiveChanged.InvokeAsync(active);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        Navigation.LocationChanged -= OnLocationChanged;
+        await base.DisposeAsync();
+    }
+
+    private bool IsHrefActive()
+    {
+        if (Href is null) return false;
+
+        var current = Navigation.ToAbsoluteUri(Navigation.Uri).AbsoluteUri;
+        var absolute = Navigation.ToAbsoluteUri(Href).AbsoluteUri;
+
+        // 1. Exact match (NavMatchMode.Exact)
+        if (Match == NavMatchMode.Exact || current.Equals(absolute, StringComparison.OrdinalIgnoreCase))
+        {
+            return current.Equals(absolute, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // 2. Prefix match (NavMatchMode.Prefix) respecting URL segments
+        if (current.StartsWith(absolute, StringComparison.OrdinalIgnoreCase))
+        {
+            // Ensure the match ends on a segment boundary (next char is '/' or end of string),
+            // to avoid a false positive of "/avatar" matching "/avatar-group"
+            if (current.Length == absolute.Length || current[absolute.Length] == '/')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task HandleClick()
+    {
+        if (!Disabled && OnClick.HasDelegate)
+            await OnClick.InvokeAsync();
+    }
+}

--- a/src/Flare.Components/Resources/FlareStrings.Designer.cs
+++ b/src/Flare.Components/Resources/FlareStrings.Designer.cs
@@ -977,7 +977,16 @@ namespace Flare.Components.Resources {
                 return ResourceManager.GetString("Nav_BackToTop", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Ищет локализованную строку, похожую на Bottom navigation.
+        /// </summary>
+        public static string Nav_BottomNavigation {
+            get {
+                return ResourceManager.GetString("Nav_BottomNavigation", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Ищет локализованную строку, похожую на Breadcrumb.
         /// </summary>

--- a/src/Flare.Components/Resources/FlareStrings.resx
+++ b/src/Flare.Components/Resources/FlareStrings.resx
@@ -138,6 +138,7 @@
 
   <!-- Navigation -->
   <data name="Nav_Navigation" xml:space="preserve"><value>Navigation</value></data>
+  <data name="Nav_BottomNavigation" xml:space="preserve"><value>Bottom navigation</value></data>
   <data name="Nav_Breadcrumb" xml:space="preserve"><value>Breadcrumb</value></data>
   <data name="Breadcrumb_Expand" xml:space="preserve"><value>Show hidden breadcrumbs</value></data>
   <data name="Nav_Pagination" xml:space="preserve"><value>Pagination</value></data>

--- a/src/Flare.Components/Resources/FlareStrings.ru.resx
+++ b/src/Flare.Components/Resources/FlareStrings.ru.resx
@@ -138,6 +138,7 @@
 
   <!-- Navigation -->
   <data name="Nav_Navigation" xml:space="preserve"><value>Навигация</value></data>
+  <data name="Nav_BottomNavigation" xml:space="preserve"><value>Нижняя навигация</value></data>
   <data name="Nav_Breadcrumb" xml:space="preserve"><value>Хлебные крошки</value></data>
   <data name="Breadcrumb_Expand" xml:space="preserve"><value>Показать скрытые крошки</value></data>
   <data name="Nav_Pagination" xml:space="preserve"><value>Пагинация</value></data>

--- a/src/Flare.Components/wwwroot/css/bottomnav.css
+++ b/src/Flare.Components/wwwroot/css/bottomnav.css
@@ -1,0 +1,82 @@
+/*
+   Mobile bottom-navigation bar (FlareBottomNav / FlareBottomNavItem). The component itself does
+   NOT set position:fixed -- it renders a plain horizontal bar with sensible height/background/
+   border/safe-area padding so the consumer can position it (fixed, sticky, or in-flow) from their
+   own layout.
+*/
+.flare-bottom-nav {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  height: var(--flare-bottom-nav-bar-height, 5rem);
+  padding-bottom: var(--flare-bottom-nav-safe-area-padding, env(safe-area-inset-bottom, 0px));
+  background: var(--flare-bottom-nav-bar-bg, var(--flare-color-surface-container));
+  border-top: 1px solid var(--flare-bottom-nav-border-color, var(--flare-color-surface-variant));
+  box-sizing: border-box;
+}
+
+/* Each item shares the bar equally. */
+.flare-bottom-nav-item {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--flare-spacing-1, 0.125rem);
+  padding: var(--flare-spacing-3, 0.375rem) var(--flare-spacing-1, 0.125rem);
+  text-decoration: none;
+  color: var(--flare-bottom-nav-inactive-color, var(--flare-color-on-surface-variant));
+  -webkit-tap-highlight-color: transparent;
+  transition: color var(--flare-motion-duration-short1, 100ms);
+}
+
+.flare-bottom-nav-item:hover {
+  color: var(--flare-bottom-nav-active-color, var(--flare-color-on-secondary-container));
+}
+
+/* Pill-shaped indicator drawn behind the icon; transparent and unsized until the item is active. */
+.flare-bottom-nav-item__indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--flare-bottom-nav-indicator-radius, var(--flare-shape-full));
+  padding-inline: var(--flare-spacing-6, 0.75rem);
+  height: 2rem;
+  background: transparent;
+  transition: background-color var(--flare-motion-duration-short1, 100ms);
+}
+
+.flare-bottom-nav-item__icon {
+  display: inline-flex;
+  font-size: var(--flare-bottom-nav-icon-size, 1.5rem);
+  line-height: 1;
+}
+
+.flare-bottom-nav-item__label {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--flare-typescale-label-medium-font);
+  font-size: var(--flare-bottom-nav-label-font-size, var(--flare-typescale-label-medium-size));
+  font-weight: var(--flare-bottom-nav-label-font-weight, 500);
+  line-height: 1.15;
+}
+
+.flare-bottom-nav-item--active {
+  color: var(--flare-bottom-nav-active-color, var(--flare-color-on-secondary-container));
+}
+
+.flare-bottom-nav-item--active .flare-bottom-nav-item__indicator {
+  background: var(--flare-bottom-nav-indicator-bg, var(--flare-color-secondary-container));
+}
+
+.flare-bottom-nav-item--active .flare-bottom-nav-item__label {
+  font-weight: var(--flare-bottom-nav-label-font-weight-active, 700);
+}
+
+.flare-bottom-nav-item--disabled {
+  opacity: var(--flare-state-disabled-opacity, 0.38);
+  pointer-events: none;
+}

--- a/src/Flare.Components/wwwroot/css/flare-components.css
+++ b/src/Flare.Components/wwwroot/css/flare-components.css
@@ -48,6 +48,7 @@
 @import 'pagination.css';
 @import 'drawer.css';
 @import 'nav.css';
+@import 'bottomnav.css';
 @import 'stepper.css';
 @import 'skeleton.css';
 @import 'avatar.css';

--- a/src/Flare.Theming/Services/CssVarMap.cs
+++ b/src/Flare.Theming/Services/CssVarMap.cs
@@ -662,6 +662,21 @@ public static class CssVarMap
         v[Css.Tokens.NavField.ActiveLeftBar] = t.Nav.ActiveLeftBar;
         #endregion
 
+        #region BOTTOM NAV
+        v[Css.Tokens.BottomNavField.BarHeight] = t.BottomNav.BarHeight;
+        v[Css.Tokens.BottomNavField.BarBg] = t.BottomNav.BarBg;
+        v[Css.Tokens.BottomNavField.BorderColor] = t.BottomNav.BorderColor;
+        v[Css.Tokens.BottomNavField.SafeAreaPadding] = t.BottomNav.SafeAreaPadding;
+        v[Css.Tokens.BottomNavField.InactiveColor] = t.BottomNav.InactiveColor;
+        v[Css.Tokens.BottomNavField.ActiveColor] = t.BottomNav.ActiveColor;
+        v[Css.Tokens.BottomNavField.IconSize] = t.BottomNav.IconSize;
+        v[Css.Tokens.BottomNavField.LabelFontSize] = t.BottomNav.LabelFontSize;
+        v[Css.Tokens.BottomNavField.LabelFontWeight] = t.BottomNav.LabelFontWeight;
+        v[Css.Tokens.BottomNavField.LabelFontWeightActive] = t.BottomNav.LabelFontWeightActive;
+        v[Css.Tokens.BottomNavField.IndicatorBg] = t.BottomNav.IndicatorBg;
+        v[Css.Tokens.BottomNavField.IndicatorRadius] = t.BottomNav.IndicatorRadius;
+        #endregion
+
         #region SWITCH
         v[Css.Tokens.SwitchField.TrackWidth] = t.Switch.TrackWidth;
         v[Css.Tokens.SwitchField.TrackHeight] = t.Switch.TrackHeight;

--- a/tests/Flare.Components.Tests/Component/BottomNavTests.cs
+++ b/tests/Flare.Components.Tests/Component/BottomNavTests.cs
@@ -1,0 +1,244 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Flare.Components.Tests.Component;
+
+// ------------------------------------------------------------------------------
+// FlareBottomNav / FlareBottomNavItem
+// ------------------------------------------------------------------------------
+
+public class C_FlareBottomNavTests : FlareTestContext
+{
+    private static RenderFragment TwoItems(string firstHref = "/", string secondHref = "/settings") => b =>
+    {
+        b.OpenComponent<FlareBottomNavItem>(0);
+        b.AddAttribute(1, "Href", firstHref);
+        b.AddAttribute(2, "Match", NavMatchMode.Exact);
+        b.AddAttribute(3, "ChildContent", (RenderFragment)(c => c.AddContent(0, "Home")));
+        b.CloseComponent();
+
+        b.OpenComponent<FlareBottomNavItem>(4);
+        b.AddAttribute(5, "Href", secondHref);
+        b.AddAttribute(6, "ChildContent", (RenderFragment)(c => c.AddContent(0, "Settings")));
+        b.CloseComponent();
+    };
+
+    [Fact]
+    public void RendersRootNav()
+    {
+        var cut = Render<FlareBottomNav>();
+
+        Assert.NotEmpty(cut.FindAll("nav.flare-bottom-nav"));
+    }
+
+    [Fact]
+    public void RendersChildItems()
+    {
+        var cut = Render<FlareBottomNav>(p => p
+            .AddChildContent(TwoItems()));
+
+        Assert.Equal(2, cut.FindAll(".flare-bottom-nav-item").Count);
+    }
+
+    [Fact]
+    public void DefaultAriaLabel_IsBottomNavigation()
+    {
+        var cut = Render<FlareBottomNav>();
+
+        Assert.Equal("Bottom navigation", cut.Find("nav").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void CustomAriaLabel_IsApplied()
+    {
+        var cut = Render<FlareBottomNav>(p => p
+            .Add(x => x.AriaLabel, "Main sections"));
+
+        Assert.Equal("Main sections", cut.Find("nav").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void RendersWithAdditionalAttributes()
+    {
+        var cut = Render<FlareBottomNav>(p => p
+            .AddUnmatched("data-testid", "bottom-nav-root"));
+
+        Assert.Equal("bottom-nav-root", cut.Find(".flare-bottom-nav").GetAttribute("data-testid"));
+    }
+}
+
+public class C_FlareBottomNavItemTests : FlareTestContext
+{
+    [Fact]
+    public void RendersAnchorTag()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/home")
+            .AddChildContent("Home"));
+
+        Assert.NotEmpty(cut.FindAll("a.flare-bottom-nav-item"));
+    }
+
+    [Fact]
+    public void RendersLabelText()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/about")
+            .AddChildContent("About Us"));
+
+        Assert.Contains("About Us", cut.Find(".flare-bottom-nav-item__label").TextContent);
+    }
+
+    [Fact]
+    public void RendersIcon()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/settings")
+            .Add(x => x.Icon, (RenderFragment)(b =>
+            {
+                b.OpenElement(0, "span");
+                b.AddAttribute(1, "id", "bn-icon");
+                b.CloseElement();
+            }))
+            .AddChildContent("Settings"));
+
+        Assert.NotEmpty(cut.FindAll(".flare-bottom-nav-item__icon"));
+        Assert.NotEmpty(cut.FindAll("#bn-icon"));
+    }
+
+    [Fact]
+    public void HrefAttribute_AppliedToAnchor()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/dashboard"));
+
+        Assert.Equal("/dashboard", cut.Find("a").GetAttribute("href"));
+    }
+
+    [Fact]
+    public void Active_True_HasActiveClassAndAriaCurrent()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/page")
+            .Add(x => x.Active, true)
+            .AddChildContent("Page"));
+
+        var a = cut.Find("a");
+        Assert.Contains("flare-bottom-nav-item--active", a.ClassName ?? "");
+        Assert.Equal("page", a.GetAttribute("aria-current"));
+    }
+
+    [Fact]
+    public void Inactive_NoAriaCurrent()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/page")
+            .AddChildContent("Page"));
+
+        Assert.False(cut.Find("a").HasAttribute("aria-current"));
+    }
+
+    [Fact]
+    public void Disabled_True_HasDisabledClass()
+    {
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/locked")
+            .Add(x => x.Disabled, true)
+            .AddChildContent("Locked"));
+
+        Assert.Contains("flare-bottom-nav-item--disabled", cut.Find("a").ClassName ?? "");
+    }
+
+    [Fact]
+    public void Click_InvokesOnClick()
+    {
+        var clicked = false;
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/x")
+            .Add(x => x.OnClick, () => clicked = true)
+            .AddChildContent("X"));
+
+        cut.Find("a").Click();
+
+        Assert.True(clicked);
+    }
+
+    [Fact]
+    public void OnActiveChanged_FiresWhenActive()
+    {
+        bool? reported = null;
+        Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/x")
+            .Add(x => x.Active, true)
+            .Add(x => x.OnActiveChanged, (bool a) => reported = a)
+            .AddChildContent("X"));
+
+        Assert.True(reported);
+    }
+
+    [Fact]
+    public void ExactMatch_ActiveOnlyOnExactRoute()
+    {
+        var nav = Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("/products/details");
+
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/products")
+            .Add(x => x.Match, NavMatchMode.Exact)
+            .AddChildContent("Products"));
+
+        Assert.DoesNotContain("flare-bottom-nav-item--active", cut.Find("a").ClassName ?? "");
+    }
+
+    [Fact]
+    public void PrefixMatch_ActiveOnChildRoute()
+    {
+        var nav = Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("/products/details");
+
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/products")
+            .Add(x => x.Match, NavMatchMode.Prefix)
+            .AddChildContent("Products"));
+
+        Assert.Contains("flare-bottom-nav-item--active", cut.Find("a").ClassName ?? "");
+    }
+
+    [Fact]
+    public void LocationChanged_UpdatesActiveStateReactively()
+    {
+        var nav = Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("/home");
+
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/settings")
+            .Add(x => x.Match, NavMatchMode.Exact)
+            .AddChildContent("Settings"));
+
+        Assert.DoesNotContain("flare-bottom-nav-item--active", cut.Find("a").ClassName ?? "");
+
+        cut.InvokeAsync(() => nav.NavigateTo("/settings"));
+        cut.WaitForState(() => cut.Find("a").ClassName?.Contains("flare-bottom-nav-item--active") ?? false);
+
+        Assert.Contains("flare-bottom-nav-item--active", cut.Find("a").ClassName ?? "");
+    }
+
+    [Fact]
+    public void LocationChanged_DeactivatesWhenNavigatingAway()
+    {
+        var nav = Services.GetRequiredService<NavigationManager>();
+        nav.NavigateTo("/settings");
+
+        var cut = Render<FlareBottomNavItem>(p => p
+            .Add(x => x.Href, "/settings")
+            .Add(x => x.Match, NavMatchMode.Exact)
+            .AddChildContent("Settings"));
+
+        Assert.Contains("flare-bottom-nav-item--active", cut.Find("a").ClassName ?? "");
+
+        cut.InvokeAsync(() => nav.NavigateTo("/home"));
+        cut.WaitForState(() => !(cut.Find("a").ClassName?.Contains("flare-bottom-nav-item--active") ?? false));
+
+        Assert.DoesNotContain("flare-bottom-nav-item--active", cut.Find("a").ClassName ?? "");
+    }
+}


### PR DESCRIPTION
Adds FlareBottomNav/FlareBottomNavItem for the horizontal, icon-over-label bottom bar pattern common on mobile, alongside the existing sidebar/rail FlareNavMenu family. Items reuse FlareNavLink's NavigationManager-based active-route detection (Prefix/Exact match, reactive on LocationChanged).

Adds BottomNavTokens (bar height/background/border, safe-area padding, active/inactive colors, icon size, label typography, active-pill indicator) wired onto DesignTokens as an optional default so no theme package needs changes. Includes bottomnav.css, CSS class/token constants, bUnit tests, and a Gallery demo page.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
