### PR TITLE
Fix: tokenize FlareColorPicker checkerboard and native slider thumb

### DIFF
--- a/src/Flare.Abstractions/Css/Tokens/ColorPickerTokens.cs
+++ b/src/Flare.Abstractions/Css/Tokens/ColorPickerTokens.cs
@@ -1,0 +1,14 @@
+namespace Flare.Css.Tokens;
+
+/// <summary>CSS variable tokens for colorpicker.</summary>
+public static class ColorPickerField
+{
+    private const string Prefix = $"{Vars.Flare}-colorpicker";
+
+    /// <summary>CSS custom-property name for the transparency-checkerboard square color token.</summary>
+    public const string CheckerColor = $"{Prefix}-checker-color";
+    /// <summary>CSS custom-property name for the hue/alpha slider thumb background token.</summary>
+    public const string ThumbBg = $"{Prefix}-thumb-bg";
+    /// <summary>CSS custom-property name for the hue/alpha slider thumb border color token.</summary>
+    public const string ThumbBorderColor = $"{Prefix}-thumb-border-color";
+}

--- a/src/Flare.Abstractions/Tokens/Components/ColorPickerTokens.cs
+++ b/src/Flare.Abstractions/Tokens/Components/ColorPickerTokens.cs
@@ -1,0 +1,22 @@
+using Flare.Css;
+using Flare.Css.Tokens;
+namespace Flare.Abstractions.Tokens.Components;
+
+/// <summary>
+/// Per-theme tokens for <c>FlareColorPicker</c>'s chrome that isn't already covered by semantic color
+/// tokens: the transparency checkerboard and the native hue/alpha range-input thumb (styled via
+/// <c>::-webkit-slider-thumb</c> / <c>::-moz-range-thumb</c>, which cannot inherit <c>currentColor</c>
+/// or an ancestor's custom property the way normal elements can). Defaults reproduce the previous
+/// fixed appearance; a theme may override any field (e.g. a dark checkerboard or an accent-ring thumb).
+/// </summary>
+public sealed record ColorPickerTokens
+{
+    /// <summary>Color of the light squares in the transparency checkerboard (preview swatch and alpha track).</summary>
+    [CssVar(ColorPickerField.CheckerColor)] public string CheckerColor { get; init; } = "#ccc";
+
+    /// <summary>Background of the hue/alpha slider's native thumb.</summary>
+    [CssVar(ColorPickerField.ThumbBg)] public string ThumbBg { get; init; } = "#fff";
+
+    /// <summary>Border color of the hue/alpha slider's native thumb.</summary>
+    [CssVar(ColorPickerField.ThumbBorderColor)] public string ThumbBorderColor { get; init; } = "rgba(0,0,0,0.3)";
+}

--- a/src/Flare.Abstractions/Tokens/DesignTokens.cs
+++ b/src/Flare.Abstractions/Tokens/DesignTokens.cs
@@ -98,6 +98,9 @@ public sealed record DesignTokens
     /// <summary>FlareTableOfContents / FlareOnThisPage tokens.</summary>
     public TableOfContentsTokens TableOfContents { get; init; } = new();
 
+    /// <summary>FlareColorPicker checkerboard + native range-thumb tokens.</summary>
+    public ColorPickerTokens ColorPicker { get; init; } = new();
+
     /// <summary>Theme-specific extras not in the core schema (e.g. Fluent focus ring vars).</summary>
     public IReadOnlyDictionary<string, string> Extended { get; init; }
         = new Dictionary<string, string>();

--- a/src/Flare.Components/wwwroot/css/colorpicker.css
+++ b/src/Flare.Components/wwwroot/css/colorpicker.css
@@ -48,10 +48,10 @@
     border: 2px solid var(--flare-color-outline-variant);
     flex-shrink: 0;
     background-image:
-        linear-gradient(45deg, #ccc 25%, transparent 25%),
-        linear-gradient(-45deg, #ccc 25%, transparent 25%),
-        linear-gradient(45deg, transparent 75%, #ccc 75%),
-        linear-gradient(-45deg, transparent 75%, #ccc 75%);
+        linear-gradient(45deg, var(--flare-colorpicker-checker-color, #ccc) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--flare-colorpicker-checker-color, #ccc) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--flare-colorpicker-checker-color, #ccc) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--flare-colorpicker-checker-color, #ccc) 75%);
     background-size: 8px 8px;
     background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
     position: relative;
@@ -131,10 +131,10 @@
     border: 2px solid var(--flare-color-outline-variant);
     flex-shrink: 0;
     background-image:
-        linear-gradient(45deg, #ccc 25%, transparent 25%),
-        linear-gradient(-45deg, #ccc 25%, transparent 25%),
-        linear-gradient(45deg, transparent 75%, #ccc 75%),
-        linear-gradient(-45deg, transparent 75%, #ccc 75%);
+        linear-gradient(45deg, var(--flare-colorpicker-checker-color, #ccc) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--flare-colorpicker-checker-color, #ccc) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--flare-colorpicker-checker-color, #ccc) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--flare-colorpicker-checker-color, #ccc) 75%);
     background-size: 8px 8px;
     background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
     position: relative;
@@ -153,7 +153,7 @@
 .flare-colorpicker__slider-alpha {
     flex: 1;
     position: relative;
-    border-radius: 9999px;
+    border-radius: var(--flare-shape-full, 9999px);
     height: 12px;
     display: flex;
     align-items: center;
@@ -167,7 +167,7 @@
     height: 12px;
     background: transparent;
     cursor: pointer;
-    border-radius: 9999px;
+    border-radius: var(--flare-shape-full, 9999px);
     outline: none;
     position: relative;
     z-index: 1;
@@ -185,10 +185,10 @@
 }
 .flare-colorpicker__slider--alpha {
     background-image:
-        linear-gradient(45deg, #ccc 25%, transparent 25%),
-        linear-gradient(-45deg, #ccc 25%, transparent 25%),
-        linear-gradient(45deg, transparent 75%, #ccc 75%),
-        linear-gradient(-45deg, transparent 75%, #ccc 75%),
+        linear-gradient(45deg, var(--flare-colorpicker-checker-color, #ccc) 25%, transparent 25%),
+        linear-gradient(-45deg, var(--flare-colorpicker-checker-color, #ccc) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, var(--flare-colorpicker-checker-color, #ccc) 75%),
+        linear-gradient(-45deg, transparent 75%, var(--flare-colorpicker-checker-color, #ccc) 75%),
         linear-gradient(to right, transparent, var(--_alpha-color, #000));
     background-size: 8px 8px, 8px 8px, 8px 8px, 8px 8px, 100% 100%;
     background-position: 0 0, 0 4px, 4px -4px, -4px 0, 0 0;
@@ -199,8 +199,8 @@
     width: 18px;
     height: 18px;
     border-radius: 50%;
-    background: #fff;
-    border: 2px solid rgba(0,0,0,0.3);
+    background: var(--flare-colorpicker-thumb-bg, #fff);
+    border: 2px solid var(--flare-colorpicker-thumb-border-color, rgba(0,0,0,0.3));
     box-shadow: var(--flare-elevation-1);
     cursor: pointer;
     transition: box-shadow var(--flare-motion-duration-short1, 100ms);
@@ -210,8 +210,8 @@
     width: 18px;
     height: 18px;
     border-radius: 50%;
-    background: #fff;
-    border: 2px solid rgba(0,0,0,0.3);
+    background: var(--flare-colorpicker-thumb-bg, #fff);
+    border: 2px solid var(--flare-colorpicker-thumb-border-color, rgba(0,0,0,0.3));
     box-shadow: var(--flare-elevation-1);
     cursor: pointer;
 }

--- a/src/Flare.Theming/Services/CssVarMap.cs
+++ b/src/Flare.Theming/Services/CssVarMap.cs
@@ -709,6 +709,12 @@ public static class CssVarMap
         v[Css.Tokens.SwitchField.DisabledOpacity] = t.Switch.DisabledOpacity;
         #endregion
 
+        #region COLOR PICKER
+        v[Css.Tokens.ColorPickerField.CheckerColor] = t.ColorPicker.CheckerColor;
+        v[Css.Tokens.ColorPickerField.ThumbBg] = t.ColorPicker.ThumbBg;
+        v[Css.Tokens.ColorPickerField.ThumbBorderColor] = t.ColorPicker.ThumbBorderColor;
+        #endregion
+
         // Extended (Глубоко кастомные оверрайды)
         foreach (var (k, val) in t.Extended)
             v[k] = val;


### PR DESCRIPTION
colorpicker.css was the only component stylesheet with untokenized values: the transparency-checkerboard squares (#ccc, x8) and the native hue/alpha range-input thumb (background:#fff, border:rgba(0,0,0,.3), x2 each) were hardcoded with no theme override path, and two border-radius:9999px rules bypassed the shared Shape.Full scale used everywhere else.

Adds ColorPickerTokens (CheckerColor, ThumbBg, ThumbBorderColor) wired through CssVarMap, and points the two radii at var(--flare-shape-full, 9999px) like every other pill in the codebase. Defaults reproduce the previous appearance exactly; themes can now override all three.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
