### PR TITLE
Refactor: consolidate FlareDatePicker month + year views (CSS dedup)

### DIFF
--- a/src/Flare.Components/wwwroot/css/datepicker.css
+++ b/src/Flare.Components/wwwroot/css/datepicker.css
@@ -147,42 +147,8 @@
 .flare-picker__day.flare-daterangepicker__day--end { border-radius: 0 var(--flare-shape-full) var(--flare-shape-full) 0; }
 .flare-picker__day.flare-daterangepicker__day--start.flare-daterangepicker__day--end { border-radius: var(--flare-shape-full); }
 
-/* Month grid */
-.flare-datepicker__month-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--flare-spacing-2);
-  padding: var(--flare-spacing-2) 0;
-}
-
-.flare-datepicker__month-btn {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: var(--flare-spacing-5) var(--flare-spacing-2);
-  border-radius: var(--flare-shape-small);
-  font-size: 0.875rem;
-  color: var(--flare-color-on-surface);
-  text-align: center;
-  font-family: inherit;
-  transition: background-color var(--flare-motion-duration-short2);
-}
-
-.flare-datepicker__month-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--flare-color-primary) 12%, transparent);
-}
-
-.flare-datepicker__month-btn--selected {
-  background: var(--flare-color-primary);
-  color: var(--flare-color-on-primary);
-  font-weight: 600;
-}
-
-.flare-datepicker__month-btn--selected:hover {
-  background: var(--flare-color-primary);
-}
-
-/* Year grid */
+/* Month + year views: two identical 3-column grids of selectable cells, so they share one rule set. */
+.flare-datepicker__month-grid,
 .flare-datepicker__year-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -190,6 +156,7 @@
   padding: var(--flare-spacing-2) 0;
 }
 
+.flare-datepicker__month-btn,
 .flare-datepicker__year-btn {
   background: transparent;
   border: none;
@@ -203,16 +170,19 @@
   transition: background-color var(--flare-motion-duration-short2);
 }
 
+.flare-datepicker__month-btn:hover:not(:disabled),
 .flare-datepicker__year-btn:hover:not(:disabled) {
   background: color-mix(in srgb, var(--flare-color-primary) 12%, transparent);
 }
 
+.flare-datepicker__month-btn--selected,
 .flare-datepicker__year-btn--selected {
   background: var(--flare-color-primary);
   color: var(--flare-color-on-primary);
   font-weight: 600;
 }
 
+.flare-datepicker__month-btn--selected:hover,
 .flare-datepicker__year-btn--selected:hover {
   background: var(--flare-color-primary);
 }


### PR DESCRIPTION
The month-view and year-view were byte-identical: the 3-column grid, the cell button, and its :hover / --selected / --selected:hover states were each declared once for __month-* and again for __year-*. Grouped every pair into one selector list. All class names are preserved (both __month-* and __year-* stay in the combined selectors), so CssClasses / CssAudit remain in sync. Zero visual change - same file, same specificity, identical declarations. -34 lines.

Verified: CssAudit "fully in sync" (1305 classes) + 1303x3 component tests green.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
