### PR TITLE
Refactor: more CSS dedup (datagrid bars, nav icons, modal scrim)

### DIFF
--- a/src/Flare.Components/wwwroot/css/confirmdialog.css
+++ b/src/Flare.Components/wwwroot/css/confirmdialog.css
@@ -1,12 +1,16 @@
-.flare-confirmdialog__backdrop {
+/* Shared modal scrim layout: a full-viewport centered backdrop over the scrim color, reused by the
+   message box and shortcuts-help overlays (each only sets its own z-index). */
+.flare-confirmdialog__backdrop,
+.flare-msgbox-scrim,
+.flare-shortcuts-help__scrim {
     position: fixed;
     inset: 0;
     background: color-mix(in srgb, var(--flare-color-scrim) calc(var(--flare-scrim-opacity, 0.32) * 100%), transparent);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
 }
+.flare-confirmdialog__backdrop { z-index: 1000; }
 
 .flare-confirmdialog {
     background: var(--flare-color-surface-container-high);

--- a/src/Flare.Components/wwwroot/css/datagrid.css
+++ b/src/Flare.Components/wwwroot/css/datagrid.css
@@ -170,14 +170,8 @@
   border-radius: 0;
 }
 
-.flare-datagrid__toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--flare-spacing-4);
-  padding: var(--flare-spacing-4) 0;
-  justify-content: flex-end;
-}
-
+/* Toolbar (top) and footer (bottom) share one end-aligned bar layout. */
+.flare-datagrid__toolbar,
 .flare-datagrid__footer {
   display: flex;
   align-items: center;

--- a/src/Flare.Components/wwwroot/css/messagebox.css
+++ b/src/Flare.Components/wwwroot/css/messagebox.css
@@ -1,12 +1,5 @@
-.flare-msgbox-scrim {
-    position: fixed;
-    inset: 0;
-    background: color-mix(in srgb, var(--flare-color-scrim) calc(var(--flare-scrim-opacity, 0.32) * 100%), transparent);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1100;
-}
+/* Scrim layout comes from the shared modal scrim (confirmdialog.css); the message box sits above other overlays. */
+.flare-msgbox-scrim { z-index: 1100; }
 
 .flare-msgbox {
     background: var(--flare-color-surface-container-high);

--- a/src/Flare.Components/wwwroot/css/nav.css
+++ b/src/Flare.Components/wwwroot/css/nav.css
@@ -88,7 +88,9 @@
   background: color-mix(in srgb, var(--flare-color-on-surface) calc(var(--flare-state-hover-opacity) * 100%), transparent);
 }
 
-.flare-nav-group__icon { display: inline-flex; font-size: 1.25rem; flex-shrink: 0; }
+/* Nav group and nav link icons share one icon layout. */
+.flare-nav-group__icon,
+.flare-nav-link__icon { display: inline-flex; font-size: 1.25rem; flex-shrink: 0; }
 .flare-nav-group__title { flex: 1; }
 
 .flare-nav-group__chevron {
@@ -160,7 +162,7 @@
   pointer-events: none;
 }
 
-.flare-nav-link__icon { display: inline-flex; font-size: 1.25rem; flex-shrink: 0; }
+/* __icon layout is shared with .flare-nav-group__icon above. */
 .flare-nav-link__text { flex: 1; min-width: 0; }
 .flare-nav-link__badge {
   background: var(--flare-color-error);

--- a/src/Flare.Components/wwwroot/css/shortcuts.css
+++ b/src/Flare.Components/wwwroot/css/shortcuts.css
@@ -1,13 +1,6 @@
 /* Keyboard-shortcuts help dialog (FlareShortcuts). */
-.flare-shortcuts-help__scrim {
-    position: fixed;
-    inset: 0;
-    background: color-mix(in srgb, var(--flare-color-scrim) calc(var(--flare-scrim-opacity, 0.32) * 100%), transparent);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-}
+/* Scrim layout comes from the shared modal scrim (confirmdialog.css). */
+.flare-shortcuts-help__scrim { z-index: 1000; }
 
 .flare-shortcuts-help {
     background: var(--flare-color-surface-container-high);


### PR DESCRIPTION
- datagrid toolbar + footer share one end-aligned bar layout (in-file pair).
- nav group-icon + link-icon share one icon layout (in-file pair).
- The confirm-dialog / message-box / shortcuts-help scrims had a byte-identical full-viewport centered backdrop differing only in z-index. Extracted the shared layout (6 props) into one rule in confirmdialog.css; each overlay keeps its own z-index in its own file. The shared props are overridden nowhere, so the rule's bundle position is cascade-safe regardless of @import order.

Selector-list grouping keeps every class present (CssAudit in sync). Zero visual change. Analyzer: 56 identical-body groups remain (mostly coincidental fills, the 3 intentional disabled tiers, and vendor-prefix pairs that must not merge).

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
