### PR TITLE
Fix: select dropdown painted see-through (lost z-index after the popu…

### DIFF
--- a/src/Flare.Components/wwwroot/css/select.css
+++ b/src/Flare.Components/wwwroot/css/select.css
@@ -49,12 +49,15 @@
     font-size: var(--flare-typescale-body-small-size);
 }
 
-/* JS-anchored (PositionAnchoredPanel) so the popup escapes a Card's overflow:hidden; the surface
-   and z-index come from .flare-listbox. Select and MultiSelect both use fixed positioning instead of
-   the shared .flare-listbox__dropdown absolute anchoring. */
+/* JS-anchored (PositionAnchoredPanel) so the popup escapes a Card's overflow:hidden. This is the
+   positioned wrapper around .flare-listbox, so the dropdown z-index MUST live here: the inner
+   .flare-listbox is position:static (its own z-index is ignored), so without a z-index on this fixed
+   wrapper the popup paints at the auto level and later-in-DOM fields overlap it (reads as a
+   see-through dropdown). Select, MultiSelect, Combobox and TagField all use this fixed wrapper. */
 .flare-select__dropdown,
 .flare-multiselect__dropdown {
     position: fixed;
+    z-index: var(--flare-z-dropdown, 1000);
 }
 
 /* Size grid (Xs..Xl) lives in input.css as the single source for the whole input family. */


### PR DESCRIPTION
…p rewrite)

The select-family rebuild moved position:fixed onto the FlarePopup wrapper (.flare-select__dropdown / .flare-multiselect__dropdown) while the z-index stayed on the inner .flare-listbox. But .flare-listbox is position:static inside that wrapper, where z-index is ignored -- so the popup painted at the auto stacking level and later-in-DOM fields (the next selects, the demo links) painted over it. On a page with several selects this read as a semi-transparent dropdown background.

Before the rewrite the fixed positioning and z-index sat on the same element, so it worked. Move the z-index onto the positioned wrapper. Verified in the Gallery on MD3 Expressive: the dropdown is now solid and covers the fields behind it (lime-behind + red-fill probe confirmed the fix).

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
