### PR TITLE
Fix: searchable select drew a second focus ring around the in-field s…

### DIFF
--- a/src/Flare.Components/wwwroot/css/a11y.css
+++ b/src/Flare.Components/wwwroot/css/a11y.css
@@ -65,11 +65,14 @@ h6[tabindex="-1"]:focus {
    click/focus doesn't draw a full ring around the field. Must come after the rules above so
    it wins at equal specificity (and beats the global :focus-visible). */
 /* The inner-input fields all render .flare-input__control (covers FlareField/Numeric/Masked/
-   TextArea/Autocomplete/TagField/Date/DateTime/Time pickers); only the combobox triggers
-   (Select/MultiSelect) carry their own focusable control element. */
+   TextArea/Combobox/TagField/Date/DateTime/Time pickers); the combobox triggers (Select/MultiSelect)
+   carry their own focusable control element, and their in-field search input (.flare-select__search)
+   is a nested text input whose ring is already shown by the surrounding field's :has(:focus-visible)
+   border -- so it must be suppressed too, otherwise it draws a second ring inside the field. */
 .flare-input__control:focus-visible,
 .flare-select__control:focus-visible,
-.flare-multiselect__control:focus-visible {
+.flare-multiselect__control:focus-visible,
+.flare-select__search:focus-visible {
     outline: none;
 }
 


### PR DESCRIPTION
…earch input

The a11y :focus-visible suppression list already covered the combobox trigger controls (.flare-input__control / .flare-select__control / .flare-multiselect__control) so a focused field shows only the surrounding well's :has(:focus-visible) border. But the in-field search input (.flare-select__search, used by searchable Select/MultiSelect) was not in that list, so the global :focus-visible outline still painted a full ring inside the field -- a doubled focus indicator (the field border + an inner ring around the search input).

Add .flare-select__search:focus-visible to the suppression list. Verified in the Gallery: clicking a searchable select now shows only the field's accent border, no inner ring.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
