### PR TITLE
Refactor: rename FlareInputControl -> FlareTextInput

### DIFF
--- a/src/Flare.Components/Input/FlareField.razor
+++ b/src/Flare.Components/Input/FlareField.razor
@@ -7,7 +7,7 @@
 @using Microsoft.AspNetCore.Components.Web
 
 @* The canonical single-line text field. Composes the shared FlareFieldChrome frame (root + label +
-   helper/error + counter) and the shared FlareInputControl (the editable element), so the chrome markup
+   helper/error + counter) and the shared FlareTextInput (the editable element), so the chrome markup
    and the input/debounce logic live once for the whole family. This component only owns the typed value
    (string <-> TValue conversion), the adornments/icons/clear that sit inside the well, and the floating
    label. *@
@@ -30,7 +30,7 @@
             {
                 <span class="@Css.Classes.Input.Icon @Css.Classes.Input.IconLeading" aria-hidden="true">@LeadingIcon</span>
             }
-            <FlareInputControl Value="@_displayText"
+            <FlareTextInput Value="@_displayText"
                                ValueChanged="EmitValue"
                                Id="@ControlId"
                                Placeholder="@Placeholder"
@@ -224,7 +224,7 @@
     }
 
     // Converts the control's raw string back to TValue (identity for string; TypeConverter otherwise),
-    // then raises the typed callback. Debounce/immediate policy lives in FlareInputControl.
+    // then raises the typed callback. Debounce/immediate policy lives in FlareTextInput.
     private async Task EmitValue(string? raw)
     {
         TValue? converted = default;

--- a/src/Flare.Components/Input/FlareTextInput.razor
+++ b/src/Flare.Components/Input/FlareTextInput.razor
@@ -2,13 +2,17 @@
 @inherits FlareComponentBase
 @using Microsoft.AspNetCore.Components.Web
 
-@* The one shared editable control for the text-input family (FlareField/Password/Masked/Numeric/TextArea
-   and the combobox/tag entry inputs). It renders the bare .flare-input__control element (an <input> or,
-   when Multiline, a <textarea>) inside the field's well, wires the aria/disabled/readonly/required
-   attributes and the Immediate/DebounceInterval oninput-vs-onchange policy, and bubbles the raw string up
-   via ValueChanged. It trafficks in STRINGS only: the parent field owns the typed value and converts to/from
-   this string, so there is no second value channel to keep in sync (the MudBlazor Value/Text echo bug
-   class). Presentational + value-less-typing = never a super-component. *@
+@* FlareTextInput -- the shared editable text element reused by the SIMPLE string fields: FlareField (and
+   FlareTextField / FlarePasswordField via it), FlareMaskedField and FlareTextArea. It renders the bare
+   .flare-input__control element (an <input> or, when Multiline, a <textarea>) inside the field's well, wires
+   the aria/disabled/readonly/required attributes and the Immediate/DebounceInterval oninput-vs-onchange
+   policy, and bubbles the raw string up via ValueChanged. It trafficks in STRINGS only, on ONE value channel:
+   the parent field owns the typed value and converts to/from this string, so there is no second value channel
+   to keep in sync (the MudBlazor Value/Text echo-bug class).
+   Fields whose input needs MORE than a single string channel deliberately render their own <input> inside the
+   same frame instead of using this: FlareNumericField (type=number + min/max/step + clamp-on-change-not-input)
+   and the date/time pickers (focus-swap + distinct mask-on-input vs parse-on-change).
+   Presentational + value-less-typing = never a super-component. *@
 
 @if (Multiline)
 {

--- a/src/Flare.Components/MaskedField/FlareMaskedField.razor
+++ b/src/Flare.Components/MaskedField/FlareMaskedField.razor
@@ -4,7 +4,7 @@
 @using System.Linq.Expressions
 @using System.Text.RegularExpressions
 
-@* Masked text field. Composes the shared FlareFieldChrome frame + FlareInputControl (immediate mode, so the
+@* Masked text field. Composes the shared FlareFieldChrome frame + FlareTextInput (immediate mode, so the
    mask applies as the user types); only the mask/preset formatting is component-specific. *@
 
 <FlareFieldChrome Variant="Variant" Size="Size"
@@ -16,7 +16,7 @@
                   Style="@Style" Attributes="AdditionalAttributes">
     <Field>
         <div class="@Css.Classes.Input.Field">
-            <FlareInputControl Value="@_display"
+            <FlareTextInput Value="@_display"
                                ValueChanged="OnInput"
                                Immediate="true"
                                Id="@ControlId"

--- a/src/Flare.Components/NumericField/FlareNumericField.razor
+++ b/src/Flare.Components/NumericField/FlareNumericField.razor
@@ -9,7 +9,7 @@
 
 @* Composes the shared FlareFieldChrome frame (root + label + helper/error). The numeric input is complex
    (type=number, min/max/step, focus-swap text mode, clamp-on-change-vs-not-on-input), so it keeps its own
-   control inside the frame's Field slot rather than the shared FlareInputControl. *@
+   control inside the frame's Field slot rather than the shared FlareTextInput. *@
 <FlareFieldChrome Variant="Variant" Size="Size"
                   Invalid="@(!string.IsNullOrEmpty(DisplayedErrorText))"
                   Disabled="Disabled" ReadOnly="ReadOnly"

--- a/src/Flare.Components/TextArea/FlareTextArea.razor
+++ b/src/Flare.Components/TextArea/FlareTextArea.razor
@@ -3,7 +3,7 @@
 @implements IFlareField<string>
 @using System.Linq.Expressions
 
-@* Multi-line text field. Composes the shared FlareFieldChrome frame + FlareInputControl in multiline mode
+@* Multi-line text field. Composes the shared FlareFieldChrome frame + FlareTextInput in multiline mode
    (a <textarea>), so it shares the family chrome + input logic and only adds the textarea-specific rows /
    auto-grow / max-lines. *@
 
@@ -17,7 +17,7 @@
                   Style="@Style">
     <Field>
         <div class="@Css.Classes.Input.Field">
-            <FlareInputControl Multiline="true"
+            <FlareTextInput Multiline="true"
                                Value="@Value"
                                ValueChanged="EmitValue"
                                Id="@ControlId"
@@ -91,7 +91,7 @@
         }
     }
 
-    // Debounce/immediate policy lives in FlareInputControl; this just raises the typed callback.
+    // Debounce/immediate policy lives in FlareTextInput; this just raises the typed callback.
     private async Task EmitValue(string? val)
     {
         await ValueChanged.InvokeAsync(val);

--- a/tests/Flare.Components.Tests/Component/TextInputTests.cs
+++ b/tests/Flare.Components.Tests/Component/TextInputTests.cs
@@ -2,13 +2,13 @@ using Microsoft.AspNetCore.Components;
 
 namespace Flare.Components.Tests.Component;
 
-// The shared editable control primitive (FlareInputControl): a string-only <input>/<textarea>.
-public class C_FlareInputControlTests : FlareTestContext
+// The shared editable control primitive (FlareTextInput): a string-only <input>/<textarea>.
+public class C_FlareTextInputTests : FlareTestContext
 {
     [Fact]
     public void Renders_input_control_by_default()
     {
-        var cut = Render<FlareInputControl>(p => p.Add(x => x.Value, "hi"));
+        var cut = Render<FlareTextInput>(p => p.Add(x => x.Value, "hi"));
         var input = cut.Find("input.flare-input__control");
         Assert.Equal("hi", input.GetAttribute("value"));
         Assert.Empty(cut.FindAll("textarea"));
@@ -17,7 +17,7 @@ public class C_FlareInputControlTests : FlareTestContext
     [Fact]
     public void Multiline_renders_textarea()
     {
-        var cut = Render<FlareInputControl>(p => p
+        var cut = Render<FlareTextInput>(p => p
             .Add(x => x.Multiline, true)
             .Add(x => x.Rows, 4));
         Assert.NotEmpty(cut.FindAll("textarea.flare-input__control"));
@@ -28,7 +28,7 @@ public class C_FlareInputControlTests : FlareTestContext
     [Fact]
     public void Forwards_placeholder_disabled_readonly_required_type_maxlength()
     {
-        var cut = Render<FlareInputControl>(p => p
+        var cut = Render<FlareTextInput>(p => p
             .Add(x => x.Placeholder, "type here")
             .Add(x => x.Disabled, true)
             .Add(x => x.ReadOnly, true)
@@ -48,7 +48,7 @@ public class C_FlareInputControlTests : FlareTestContext
     public void Change_emits_raw_string()
     {
         string? captured = null;
-        var cut = Render<FlareInputControl>(p => p
+        var cut = Render<FlareTextInput>(p => p
             .Add(x => x.ValueChanged, EventCallback.Factory.Create<string?>(this, v => captured = v)));
         cut.Find("input").Change("hello");
         Assert.Equal("hello", captured);
@@ -58,7 +58,7 @@ public class C_FlareInputControlTests : FlareTestContext
     public void Immediate_emits_on_input()
     {
         string? captured = null;
-        var cut = Render<FlareInputControl>(p => p
+        var cut = Render<FlareTextInput>(p => p
             .Add(x => x.Immediate, true)
             .Add(x => x.DebounceInterval, 0)
             .Add(x => x.ValueChanged, EventCallback.Factory.Create<string?>(this, v => captured = v)));
@@ -70,7 +70,7 @@ public class C_FlareInputControlTests : FlareTestContext
     public void Non_immediate_does_not_emit_on_input()
     {
         string? captured = null;
-        var cut = Render<FlareInputControl>(p => p
+        var cut = Render<FlareTextInput>(p => p
             .Add(x => x.Immediate, false)
             .Add(x => x.ValueChanged, EventCallback.Factory.Create<string?>(this, v => captured = v)));
         cut.Find("input").Input("abc");
@@ -80,7 +80,7 @@ public class C_FlareInputControlTests : FlareTestContext
     [Fact]
     public void Aria_invalid_and_describedby_are_wired()
     {
-        var cut = Render<FlareInputControl>(p => p
+        var cut = Render<FlareTextInput>(p => p
             .Add(x => x.AriaInvalid, true)
             .Add(x => x.AriaDescribedBy, "err-1")
             .Add(x => x.Id, "ctl-1"));


### PR DESCRIPTION
FlareInputControl overpromised: it is not the input control for the whole field family, only the shared editable text element (an <input> or, in Multiline mode, a <textarea>) that the SIMPLE string fields reuse
- FlareField (and TextField/PasswordField via it), FlareMaskedField, FlareTextArea. FlareNumericField and the date/time pickers deliberately render their own <input> because they need more than one string channel (number type + min/max/step + clamp-on-change-not-input; focus-swap + distinct mask-on-input vs parse-on- change). Rename it to FlareTextInput to match what it actually is, rename its test file/class to match, and fix the header comment which wrongly claimed Numeric + combobox/tag used it.

Pure symbol rename (component class = filename). Components 1386 + Core 70 green x3 TFMs.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
