### PR TITLE
Refactor: theme-agnostic button group via ButtonGroupTokens (kill the…

### DIFF
--- a/src/Flare.Abstractions/Css/Tokens/ButtonGroupTokens.cs
+++ b/src/Flare.Abstractions/Css/Tokens/ButtonGroupTokens.cs
@@ -1,0 +1,25 @@
+namespace Flare.Css.Tokens;
+
+/// <summary>
+/// CSS variable tokens for <c>FlareButtonGroup</c>. The base <c>buttongroup.css</c> is theme-agnostic:
+/// it reads these tokens (all defaulting to a plain, un-connected row of buttons) and each theme SETS
+/// the bundle it wants - a connected look (zero gap, a small negative overlap that collapses adjacent
+/// borders, flat inner corners) or a separated look (a positive gap, no overlap, rounded inner corners).
+/// </summary>
+public static class ButtonGroup
+{
+    private const string FlareGroup = $"{Vars.Flare}-btn-group";
+
+    /// <summary>CSS custom-property name for the gap between segments (positive = separated segments).</summary>
+    public const string Gap = $"{FlareGroup}-gap";
+    /// <summary>CSS custom-property name for the segment overlap: a (usually negative) inline/block margin on
+    /// non-first segments that collapses two adjacent 1px borders into one shared seam. <c>0</c> = no overlap.</summary>
+    public const string Overlap = $"{FlareGroup}-overlap";
+    /// <summary>CSS custom-property name for the OUTER (leading/trailing group-end) corner radius.</summary>
+    public const string OuterRadius = $"{FlareGroup}-outer-radius";
+    /// <summary>CSS custom-property name for the INNER (interior seam) corner radius.</summary>
+    public const string InnerRadius = $"{FlareGroup}-inner-radius";
+    /// <summary>CSS custom-property name for the z-index applied to a hovered/focused segment so its border
+    /// and focus ring are not clipped by an overlapping neighbour.</summary>
+    public const string ZActive = $"{FlareGroup}-z-active";
+}

--- a/src/Flare.Abstractions/Tokens/Components/ButtonGroupTokens.cs
+++ b/src/Flare.Abstractions/Tokens/Components/ButtonGroupTokens.cs
@@ -1,0 +1,32 @@
+using Flare.Css;
+using Flare.Css.Tokens;
+namespace Flare.Abstractions.Tokens.Components;
+
+/// <summary>
+/// Per-theme geometry tokens for <c>FlareButtonGroup</c>. The base <c>buttongroup.css</c> carries no
+/// visual opinion - it reads these tokens (all defaulting to a plain, un-connected button row) - so a
+/// theme SETS the model it wants instead of a theme UNSETTING another's baked defaults. A connected look
+/// = zero <see cref="Gap"/> + a small negative <see cref="Overlap"/> (collapses adjacent borders) + flat
+/// <see cref="InnerRadius"/>; a separated look = positive <see cref="Gap"/> + zero <see cref="Overlap"/> +
+/// rounded <see cref="InnerRadius"/>. <see cref="OuterRadius"/> may be a size-adaptive capsule
+/// (<c>calc(var(--_flare-btn-height) / 2)</c>) since the button's size class sets that height variable.
+/// </summary>
+public sealed record ButtonGroupTokens
+{
+    /// <summary>Gap between segments (positive = separated). Connected themes use <c>0</c>.</summary>
+    [CssVar(ButtonGroup.Gap)] public required string Gap { get; init; }
+
+    /// <summary>Segment overlap: a (usually negative) margin on non-first segments that collapses two
+    /// adjacent 1px borders into one shared seam. <c>0</c> = no overlap (separated).</summary>
+    [CssVar(ButtonGroup.Overlap)] public required string Overlap { get; init; }
+
+    /// <summary>Outer (leading/trailing group-end) corner radius.</summary>
+    [CssVar(ButtonGroup.OuterRadius)] public required string OuterRadius { get; init; }
+
+    /// <summary>Inner (interior seam) corner radius. <c>0</c> = flat/segmented; a shape token = rounded.</summary>
+    [CssVar(ButtonGroup.InnerRadius)] public required string InnerRadius { get; init; }
+
+    /// <summary>Z-index applied to a hovered/focused segment so its border and ring are not clipped by an
+    /// overlapping neighbour.</summary>
+    [CssVar(ButtonGroup.ZActive)] public required string ZActive { get; init; }
+}

--- a/src/Flare.Abstractions/Tokens/DesignTokens.cs
+++ b/src/Flare.Abstractions/Tokens/DesignTokens.cs
@@ -36,6 +36,8 @@ public sealed record DesignTokens
     public required AlertTokens Alert { get; init; }
     /// <summary>Button token.</summary>
     public required ButtonTokens Button { get; init; }
+    /// <summary>Button group token.</summary>
+    public required ButtonGroupTokens ButtonGroup { get; init; }
     /// <summary>Split button token.</summary>
     public required SplitButtonTokens SplitButton { get; init; }
     /// <summary>Toggle button token.</summary>

--- a/src/Flare.Components/wwwroot/css/buttongroup.css
+++ b/src/Flare.Components/wwwroot/css/buttongroup.css
@@ -1,6 +1,17 @@
+/* ==========================================================================
+   FlareButtonGroup - THEME-AGNOSTIC base. This file carries NO visual opinion: it only reads the
+   --flare-btn-group-* tokens, every one of which DEFAULTS to a plain, un-connected row of buttons
+   (gap 0, no overlap, square corners). Each theme SETS the model it wants via ButtonGroupTokens:
+     - connected  = gap 0 + a negative --overlap that collapses adjacent borders + flat --inner-radius
+     - separated  = a positive --gap + zero --overlap + rounded --inner-radius
+   (see Flare.Abstractions/Tokens/Components/ButtonGroupTokens.cs). Logical margins/corners so RTL mirrors
+   automatically; no per-size fan-out (the outer radius may be a calc(--_flare-btn-height / 2) capsule and
+   the button's own size class supplies that height). */
+
 .flare-btn-group {
     display: inline-flex;
     box-sizing: border-box;
+    gap: var(--flare-btn-group-gap, 0);
 }
 
 .flare-btn-group--full {
@@ -12,110 +23,50 @@
     flex-direction: column;
 }
 
-/* ==========================================================================
-   SEAMS AND DIVIDERS
-   ========================================================================== */
-
-/* Horizontal group: overlap buttons horizontally by 1px */
+/* Connected overlap: a (usually negative) leading margin on every non-first segment pulls it over its
+   neighbour so two 1px borders collapse into one seam. Default 0 = separated / no overlap. Logical
+   properties -> correct in both LTR and RTL and for vertical stacks. */
 .flare-btn-group:not(.flare-btn-group--vertical) .flare-btn:not(:first-child) {
-    margin-left: -1px;
+    margin-inline-start: var(--flare-btn-group-overlap, 0);
 }
-
-/* Vertical group: overlap vertically */
 .flare-btn-group--vertical .flare-btn:not(:first-child) {
-    margin-top: -1px;
+    margin-block-start: var(--flare-btn-group-overlap, 0);
 }
 
-/* Focus/hover ring above neighbors so an adjacent button does not clip it */
+/* Raise the hovered/focused segment so its border + focus ring are not clipped by an overlapping
+   neighbour. Only matters in the connected (overlapping) mode; harmless when separated. */
 .flare-btn-group .flare-btn:hover,
 .flare-btn-group .flare-btn:focus-visible {
-    z-index: 1;
+    z-index: var(--flare-btn-group-z-active, 1);
 }
 
 /* ==========================================================================
-   PER-CORNER RADIUS OVERRIDE
-   The group drives the button's per-corner tokens (--flare-btn-radius-{size}-{side}).
-   A button reads variables for ITS size ONLY, so one rule can safely
-   set all 5 sizes at once. Horizontal and vertical are split via :not()
-   so the rules do not conflict; a lone button gets both sides (first+last).
+   PER-CORNER RADIUS - position based, driven by two group tokens (outer/inner). Interior corners read
+   --inner-radius; the group's two ends read --outer-radius. Logical corners so first/last map to the
+   correct visual ends in RTL. No xs..xl fan-out: the button reads --_flare-btn-height for a capsule.
    ========================================================================== */
 
-/* 1. Flatten ALL corners on every button in the group (any size) */
+/* Every segment: all four corners default to the interior radius. */
 .flare-btn-group .flare-btn {
-    --flare-btn-radius-xs-top-left: 0px !important;
-    --flare-btn-radius-xs-top-right: 0px !important;
-    --flare-btn-radius-xs-bottom-right: 0px !important;
-    --flare-btn-radius-xs-bottom-left: 0px !important;
-    --flare-btn-radius-sm-top-left: 0px !important;
-    --flare-btn-radius-sm-top-right: 0px !important;
-    --flare-btn-radius-sm-bottom-right: 0px !important;
-    --flare-btn-radius-sm-bottom-left: 0px !important;
-    --flare-btn-radius-md-top-left: 0px !important;
-    --flare-btn-radius-md-top-right: 0px !important;
-    --flare-btn-radius-md-bottom-right: 0px !important;
-    --flare-btn-radius-md-bottom-left: 0px !important;
-    --flare-btn-radius-lg-top-left: 0px !important;
-    --flare-btn-radius-lg-top-right: 0px !important;
-    --flare-btn-radius-lg-bottom-right: 0px !important;
-    --flare-btn-radius-lg-bottom-left: 0px !important;
-    --flare-btn-radius-xl-top-left: 0px !important;
-    --flare-btn-radius-xl-top-right: 0px !important;
-    --flare-btn-radius-xl-bottom-right: 0px !important;
-    --flare-btn-radius-xl-bottom-left: 0px !important;
+    border-radius: var(--flare-btn-group-inner-radius, 0);
 }
 
-/* 2. HORIZONTAL - first button: round the LEFT corners to the theme shape */
+/* Horizontal: first segment rounds its LEADING (start) end, last segment its TRAILING (end) end. */
 .flare-btn-group:not(.flare-btn-group--vertical) .flare-btn:first-child {
-    --flare-btn-radius-xs-top-left: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-xs-bottom-left: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-sm-top-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-sm-bottom-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-top-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-bottom-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-lg-top-left: var(--flare-shape-medium) !important;
-    --flare-btn-radius-lg-bottom-left: var(--flare-shape-medium) !important;
-    --flare-btn-radius-xl-top-left: var(--flare-shape-large) !important;
-    --flare-btn-radius-xl-bottom-left: var(--flare-shape-large) !important;
+    border-start-start-radius: var(--flare-btn-group-outer-radius, 0);
+    border-end-start-radius: var(--flare-btn-group-outer-radius, 0);
 }
-
-/* HORIZONTAL - last button: round the RIGHT corners */
 .flare-btn-group:not(.flare-btn-group--vertical) .flare-btn:last-child {
-    --flare-btn-radius-xs-top-right: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-xs-bottom-right: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-sm-top-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-sm-bottom-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-top-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-bottom-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-lg-top-right: var(--flare-shape-medium) !important;
-    --flare-btn-radius-lg-bottom-right: var(--flare-shape-medium) !important;
-    --flare-btn-radius-xl-top-right: var(--flare-shape-large) !important;
-    --flare-btn-radius-xl-bottom-right: var(--flare-shape-large) !important;
+    border-start-end-radius: var(--flare-btn-group-outer-radius, 0);
+    border-end-end-radius: var(--flare-btn-group-outer-radius, 0);
 }
 
-/* 3. VERTICAL - first button: round the TOP corners */
+/* Vertical: first segment rounds its TOP corners, last segment its BOTTOM corners. */
 .flare-btn-group--vertical .flare-btn:first-child {
-    --flare-btn-radius-xs-top-left: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-xs-top-right: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-sm-top-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-sm-top-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-top-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-top-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-lg-top-left: var(--flare-shape-medium) !important;
-    --flare-btn-radius-lg-top-right: var(--flare-shape-medium) !important;
-    --flare-btn-radius-xl-top-left: var(--flare-shape-large) !important;
-    --flare-btn-radius-xl-top-right: var(--flare-shape-large) !important;
+    border-start-start-radius: var(--flare-btn-group-outer-radius, 0);
+    border-start-end-radius: var(--flare-btn-group-outer-radius, 0);
 }
-
-/* VERTICAL - last button: round the BOTTOM corners */
 .flare-btn-group--vertical .flare-btn:last-child {
-    --flare-btn-radius-xs-bottom-left: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-xs-bottom-right: var(--flare-shape-extra-small) !important;
-    --flare-btn-radius-sm-bottom-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-sm-bottom-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-bottom-left: var(--flare-shape-small) !important;
-    --flare-btn-radius-md-bottom-right: var(--flare-shape-small) !important;
-    --flare-btn-radius-lg-bottom-left: var(--flare-shape-medium) !important;
-    --flare-btn-radius-lg-bottom-right: var(--flare-shape-medium) !important;
-    --flare-btn-radius-xl-bottom-left: var(--flare-shape-large) !important;
-    --flare-btn-radius-xl-bottom-right: var(--flare-shape-large) !important;
+    border-end-start-radius: var(--flare-btn-group-outer-radius, 0);
+    border-end-end-radius: var(--flare-btn-group-outer-radius, 0);
 }

--- a/src/Flare.Components/wwwroot/css/rtl.css
+++ b/src/Flare.Components/wwwroot/css/rtl.css
@@ -163,15 +163,8 @@
    ============================================ */
 
 /* Button - no RTL adjustment needed */
-/* ButtonGroup - reverse */
-[dir="rtl"] .flare-btn-group {
-  direction: rtl;
-}
-
-[dir="rtl"] .flare-btn-group .flare-btn + .flare-btn {
-  border-left: none;
-  border-right: 1px solid;
-}
+/* ButtonGroup - no RTL rules needed: buttongroup.css uses logical properties (margin-inline/block-start
+   for the overlap, border-*-*-radius logical corners), which mirror automatically under [dir="rtl"]. */
 
 /* SplitButton - reverse */
 [dir="rtl"] .flare-split-btn {

--- a/src/Flare.Theme.Aero/AeroTokens.cs
+++ b/src/Flare.Theme.Aero/AeroTokens.cs
@@ -275,6 +275,7 @@ internal class AeroTokens
         Badge = Badge,
         Alert = Alert,
         Button = Button,
+        ButtonGroup = MaterialDesignTokens.Design.ButtonGroup,
         SplitButton = SplitButton,
         ToggleButton = ToggleButton,
         Fab = Fab,

--- a/src/Flare.Theme.FluentUI2.Tokens/FluentUI2Tokens.cs
+++ b/src/Flare.Theme.FluentUI2.Tokens/FluentUI2Tokens.cs
@@ -145,6 +145,17 @@ public class FluentUI2Tokens
         LabelXl = Typography.TitleLarge,
     };
 
+    // Connected button group (Fluent's segmented look): touching segments, 1px overlap collapsing the
+    // shared border, small rounded ends, flat interior corners.
+    internal static readonly ButtonGroupTokens ButtonGroup = new()
+    {
+        Gap = "0",
+        Overlap = "-1px",
+        OuterRadius = "var(--flare-shape-small)",
+        InnerRadius = "0",
+        ZActive = "1",
+    };
+
     internal static readonly SplitButtonTokens SplitButton = new()
     {
         Gap = "1px", // Thin 1px Microsoft seam between the two parts
@@ -815,6 +826,7 @@ public class FluentUI2Tokens
         Badge = Badge,
         Alert = Alert,
         Button = Button,
+        ButtonGroup = ButtonGroup,
         SplitButton = SplitButton,
         ToggleButton = ToggleButton,
         Fab = Fab,

--- a/src/Flare.Theme.LiquidGlass/LiquidGlassTokens.cs
+++ b/src/Flare.Theme.LiquidGlass/LiquidGlassTokens.cs
@@ -320,6 +320,7 @@ internal class LiquidGlassTokens
         Badge = Badge,
         Alert = Alert,
         Button = Button,
+        ButtonGroup = MaterialDesignTokens.Design.ButtonGroup,
         SplitButton = SplitButton,
         ToggleButton = ToggleButton,
         Fab = Fab,

--- a/src/Flare.Theme.MaterialDesign2/MaterialDesign2Tokens.cs
+++ b/src/Flare.Theme.MaterialDesign2/MaterialDesign2Tokens.cs
@@ -188,6 +188,7 @@ internal static class MaterialDesign2Tokens
         Motion = Motion,
         State = State,
         Button = Button,
+        ButtonGroup = MaterialDesignTokens.Design.ButtonGroup,
         SplitButton = MaterialDesignTokens.Design.SplitButton,
         Fab = Fab,
         Menu = Menu,

--- a/src/Flare.Theme.MaterialDesign3.Tokens/MaterialDesignTokens.cs
+++ b/src/Flare.Theme.MaterialDesign3.Tokens/MaterialDesignTokens.cs
@@ -154,6 +154,17 @@ public class MaterialDesignTokens
         LabelXl = Typography.HeadlineLarge,
     };
 
+    // CONNECTED button group: no gap, a 1px negative overlap that collapses adjacent borders into one
+    // seam, rounded group ends, flat interior corners. MD3 Expressive overrides this to a separated look.
+    internal static readonly ButtonGroupTokens ButtonGroup = new()
+    {
+        Gap = "0",
+        Overlap = "-1px",
+        OuterRadius = "var(--flare-shape-small)",
+        InnerRadius = "0",
+        ZActive = "1",
+    };
+
     internal static readonly SplitButtonTokens SplitButton = new()
     {
         Gap = "0.125rem", // 2dp (between space)
@@ -780,6 +791,7 @@ public class MaterialDesignTokens
         Badge = Badge,
         Alert = Alert,
         Button = Button,
+        ButtonGroup = ButtonGroup,
         SplitButton = SplitButton,
         ToggleButton = ToggleButton,
         Fab = Fab,

--- a/src/Flare.Theme.MaterialDesign3Expressive/MaterialDesign3ExpressiveTheme.cs
+++ b/src/Flare.Theme.MaterialDesign3Expressive/MaterialDesign3ExpressiveTheme.cs
@@ -1,6 +1,7 @@
 using Flare.Abstractions;
 using Flare.Theming;
 using Flare.Abstractions.Tokens;
+using Flare.Abstractions.Tokens.Components;
 using Flare.Theme.MaterialDesign3.Tokens;
 
 namespace Flare.Theme.MaterialDesign3Expressive;
@@ -16,7 +17,19 @@ public sealed class Md3Theme : ITheme
 
     public string Id => ThemeId;
     public string DisplayName => "Material Design 3 Expressive";
-    public DesignTokens Design => MaterialDesignTokens.Design;
+    public DesignTokens Design => MaterialDesignTokens.Design with
+    {
+        // SEPARATED button group (Expressive): a real 2dp gap, no overlap, rounded interior corners and
+        // full-capsule ends. Purely a token bundle - the base buttongroup.css is untouched (no override).
+        ButtonGroup = new ButtonGroupTokens
+        {
+            Gap = "0.125rem",
+            Overlap = "0",
+            OuterRadius = "calc(var(--_flare-btn-height, var(--flare-btn-height-md, 3rem)) / 2)",
+            InnerRadius = "var(--flare-shape-small)",
+            ZActive = "1",
+        },
+    };
     public string DefaultPaletteId => Md3Palettes.Violet.Id;
     public IReadOnlyList<Palette> Palettes => Md3Palettes.All;
     public IPaletteGenerator? PaletteGenerator => Md3TonalGenerator.Instance;

--- a/src/Flare.Theme.MaterialDesign3Expressive/wwwroot/css/components/button-group.css
+++ b/src/Flare.Theme.MaterialDesign3Expressive/wwwroot/css/components/button-group.css
@@ -1,128 +1,22 @@
 /* ==========================================================================
-   MD3 EXPRESSIVE button group: SEPARATED segments with a gap (like split button)
-   - a gap between buttons, not an overlap;
-   - inner corners rounded (shape-small ~ 8dp), outer ends - capsule;
-   - on hover/press the segment morphs into a full capsule.
-   Fluent stays "connected" - this file is for the MD3 theme only.
+   MD3 EXPRESSIVE button group. The SEPARATED geometry (2dp gap, no overlap, rounded inner corners,
+   capsule ends) now comes ENTIRELY from the separated ButtonGroupTokens bundle
+   (MaterialDesign3ExpressiveTheme.Design.ButtonGroup) consumed by the neutral base buttongroup.css -
+   there is NO geometry override here anymore. Only the genuinely-interactive Expressive behaviour
+   remains: a segment morphs into a full capsule on hover/press.
 
-   Wrapped in @scope so the group's MD3 geometry does not leak into a nested scope
-   of another theme (Fluent via FlareThemeScope inside an MD3 app): the lower bound
-   cuts the cascade at any nested .flare-root that is NOT md3-expressive.
-   In a foreign scope the group falls back to the base connected style (buttongroup.css).
+   @scope so this interaction does not leak into a nested non-md3-expressive theme (Fluent via
+   FlareThemeScope inside an MD3 app); the lower bound cuts the cascade at any nested .flare-root that is
+   not md3-expressive.
    ========================================================================== */
 @scope (.flare-theme-md3-expressive) to (.flare-root:not(.flare-theme-md3-expressive)) {
 
-    /* 1. Gap between segments (2dp, like split button) */
-    .flare-btn-group {
-        gap: var(--flare-btn-group-gap, 0.125rem);
-    }
-
-    /* 2. Remove the -1px overlap and the seam border of connected mode */
-    .flare-btn-group:not(.flare-btn-group--vertical) .flare-btn:not(:first-child) {
-        margin-left: 0;
-    }
-
-    .flare-btn-group--vertical .flare-btn:not(:first-child) {
-        margin-top: 0;
-    }
-
-    /* 3. Inner corners of ALL segments - small rounding (instead of flat 0) */
-    .flare-btn-group .flare-btn {
-        --flare-btn-radius-xs-top-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xs-top-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xs-bottom-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xs-bottom-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-sm-top-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-sm-top-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-sm-bottom-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-sm-bottom-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-md-top-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-md-top-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-md-bottom-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-md-bottom-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-lg-top-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-lg-top-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-lg-bottom-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-lg-bottom-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xl-top-left: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xl-top-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xl-bottom-right: var(--flare-shape-small, 0.5rem) !important;
-        --flare-btn-radius-xl-bottom-left: var(--flare-shape-small, 0.5rem) !important;
-    }
-
-    /* ======================================================================
-       OUTER ENDS - full "capsule" (height / 2)
-       A button reads tokens for its own size only, so one rule sets all 5.
-       Horizontal and vertical are split via :not() so they do not conflict.
-       ====================================================================== */
-
-    /* HORIZONTAL - first button: left ends to capsule */
-    .flare-btn-group:not(.flare-btn-group--vertical) .flare-btn:first-child {
-        --flare-btn-radius-xs-top-left: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-xs-bottom-left: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-sm-top-left: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-sm-bottom-left: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-md-top-left: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-md-bottom-left: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-lg-top-left: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-lg-bottom-left: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-xl-top-left: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-        --flare-btn-radius-xl-bottom-left: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-    }
-
-    /* HORIZONTAL - last button: right ends to capsule */
-    .flare-btn-group:not(.flare-btn-group--vertical) .flare-btn:last-child {
-        --flare-btn-radius-xs-top-right: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-xs-bottom-right: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-sm-top-right: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-sm-bottom-right: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-md-top-right: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-md-bottom-right: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-lg-top-right: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-lg-bottom-right: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-xl-top-right: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-        --flare-btn-radius-xl-bottom-right: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-    }
-
-    /* VERTICAL - first button: top ends to capsule */
-    .flare-btn-group--vertical .flare-btn:first-child {
-        --flare-btn-radius-xs-top-left: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-xs-top-right: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-sm-top-left: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-sm-top-right: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-md-top-left: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-md-top-right: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-lg-top-left: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-lg-top-right: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-xl-top-left: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-        --flare-btn-radius-xl-top-right: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-    }
-
-    /* VERTICAL - last button: bottom ends to capsule */
-    .flare-btn-group--vertical .flare-btn:last-child {
-        --flare-btn-radius-xs-bottom-left: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-xs-bottom-right: calc(var(--flare-btn-height-xs, 2rem) / 2) !important;
-        --flare-btn-radius-sm-bottom-left: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-sm-bottom-right: calc(var(--flare-btn-height-sm, 2.5rem) / 2) !important;
-        --flare-btn-radius-md-bottom-left: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-md-bottom-right: calc(var(--flare-btn-height-md, 3rem) / 2) !important;
-        --flare-btn-radius-lg-bottom-left: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-lg-bottom-right: calc(var(--flare-btn-height-lg, 3.5rem) / 2) !important;
-        --flare-btn-radius-xl-bottom-left: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-        --flare-btn-radius-xl-bottom-right: calc(var(--flare-btn-height-xl, 4rem) / 2) !important;
-    }
-
-    /* ======================================================================
-       EXPRESSIVE: segment morphs into a round capsule on interaction [specs]
-       Radius is taken from the ACTUAL height (--_flare-btn-height sets the size class),
-       so one rule covers all sizes. border-radius (0,4,0) overrides both
-       the single-button morph (0,3,0) and scoped (0,2,0) - no !important needed.
-       ====================================================================== */
+    /* Segment morphs into a round capsule on interaction. Radius from the ACTUAL height
+       (--_flare-btn-height, set by the button's size class), so one rule covers all sizes.
+       !important so it overrides the base group's per-corner outer/inner rules on every corner. */
     .flare-btn-group .flare-btn:hover,
     .flare-btn-group .flare-btn:focus-visible,
     .flare-btn-group .flare-btn:active {
-        border-radius: calc(var(--_flare-btn-height, var(--flare-btn-height-md, 3rem)) / 2);
-        /* keep z-index via !important: specificity EQUALS scoped z-index:1 (tie), load order decides */
-        z-index: 2 !important;
+        border-radius: calc(var(--_flare-btn-height, var(--flare-btn-height-md, 3rem)) / 2) !important;
     }
 }

--- a/src/Flare.Theme.VisualStudio/VisualStudioTokens.cs
+++ b/src/Flare.Theme.VisualStudio/VisualStudioTokens.cs
@@ -318,6 +318,7 @@ internal class VisualStudioTokens
         Badge = Badge,
         Alert = Alert,
         Button = Button,
+        ButtonGroup = FluentUI2Tokens.Design.ButtonGroup,
         SplitButton = SplitButton,
         ToggleButton = ToggleButton,
         Fab = Fab,

--- a/src/Flare.Theming/Services/CssVarMap.cs
+++ b/src/Flare.Theming/Services/CssVarMap.cs
@@ -189,6 +189,14 @@ public static class CssVarMap
         FlattenBtnLabel(v, "xl", t.Button.LabelXl);
         #endregion
 
+        #region BUTTON GROUP
+        v[Css.Tokens.ButtonGroup.Gap] = t.ButtonGroup.Gap;
+        v[Css.Tokens.ButtonGroup.Overlap] = t.ButtonGroup.Overlap;
+        v[Css.Tokens.ButtonGroup.OuterRadius] = t.ButtonGroup.OuterRadius;
+        v[Css.Tokens.ButtonGroup.InnerRadius] = t.ButtonGroup.InnerRadius;
+        v[Css.Tokens.ButtonGroup.ZActive] = t.ButtonGroup.ZActive;
+        #endregion
+
         #region SPLIT BUTTON
         // Base seam gap
         v[Css.Tokens.SplitButton.Gap] = t.SplitButton.Gap;


### PR DESCRIPTION
… override-the-base war)

The base buttongroup.css hard-coded the entire 'connected' model (margin:-1px overlap, 20x !important flat inner corners, a size->shape outer mapping) and MD3 Expressive spent its whole button-group.css reverting it (margin:0, re-round the same 20 vars, capsule ends) - two files writing the same custom properties to opposite values, winning only on load order. There was no ButtonGroupTokens record and the lone --flare-btn-group-gap was a phantom (referenced only with a literal fallback).

Introduce ButtonGroupTokens (Gap, Overlap, OuterRadius, InnerRadius, ZActive - all required) wired through DesignTokens + CssVarMap. Rewrite buttongroup.css as a NEUTRAL, opinion-free base that only reads those tokens (all defaulting to a plain button row), with logical margins/corners (RTL mirrors automatically, so the stale rtl.css seam rules are deleted) and NO per-size fan-out (the button's size class supplies --_flare-btn-height for a capsule outer radius).

Each theme now SETS the model instead of UNSETTING another's default:
- MD3 / Fluent / MD2 / Aero / LiquidGlass / VS = connected bundle (gap 0, overlap -1px, flat inner, shaped ends).
- MD3 Expressive = separated bundle (gap 2dp, no overlap, 8dp inner, capsule ends) via Design with{} - its button-group.css collapses from 129 lines to just the hover capsule-morph (genuine theme behaviour).

Modeled on Blazorise (dumb component, provider owns 100% of geometry) + Fluent (calc-over-token sizing). Gallery-verified: Fluent2 connected (gap 0, overlap -1px, flat inner, 4px ends, clean single seams) and MD3 Expressive separated (gap 2px, 8px inner, 24px capsule ends) both render from the SAME base. Core 70 + Components 1386 green x3 TFMs; CssAudit green.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
