### PR TITLE
Test: guard --flare-* token/CSS/theme sync (token counterpart of the …

### DIFF
--- a/tests/Flare.Core.Tests/CssAuditTests.cs
+++ b/tests/Flare.Core.Tests/CssAuditTests.cs
@@ -3,10 +3,9 @@ using Flare.Tools.CssAudit;
 namespace Flare.Core.Tests;
 
 /// <summary>
-/// Build-gate for the CSS contract: the same audit the <c>cssaudit</c> CLI runs, executed in-process
-/// during <c>dotnet test</c>. Fails when a class is added to Flare.Components CSS without a
-/// <c>Flare.Css.Classes</c> constant, a constant loses its CSS rule, or a theme introduces a class
-/// the base does not define.
+/// Build-gate for the CSS contract: the same audits the <c>cssaudit</c> CLI runs, executed in-process
+/// during <c>dotnet test</c>. One check guards CSS classes, the other guards <c>--flare-*</c> design
+/// tokens. Each fails when Flare.Components CSS, the <c>Flare.Css</c> registry and the themes drift apart.
 /// </summary>
 public sealed class CssAuditTests
 {
@@ -18,6 +17,24 @@ public sealed class CssAuditTests
         Assert.True(report.InSync,
             "CssClasses / Flare.Components CSS / themes drifted out of sync. " +
             "Run `dotnet run --project tools/Flare.CssAudit -- check` for details. Findings:\n  " +
+            string.Join("\n  ", report.AllFindings));
+    }
+
+    /// <summary>
+    /// Token counterpart of <see cref="CssClasses_Components_And_Themes_StayInSync"/>. Every token the
+    /// component CSS reads has a <c>Css.Tokens</c> constant and every constant is read, so this fails when
+    /// a <c>--flare-*</c> token is added to Flare.Components CSS without a <c>Css.Tokens</c> constant
+    /// (<c>[T+]</c>), a constant loses its last CSS reference (<c>[T-]</c>), or a theme references a token
+    /// that is neither declared nor present in the base CSS (<c>[T~]</c>).
+    /// </summary>
+    [Fact]
+    public void CssTokens_Components_And_Themes_StayInSync()
+    {
+        var report = CssAudit.RunTokens();
+
+        Assert.True(report.InSync,
+            "Css.Tokens / Flare.Components CSS / themes drifted out of sync. " +
+            "Run `dotnet run --project tools/Flare.CssAudit -- tokens` for details. Findings:\n  " +
             string.Join("\n  ", report.AllFindings));
     }
 }

--- a/tools/Flare.CssAudit/CssAudit.cs
+++ b/tools/Flare.CssAudit/CssAudit.cs
@@ -36,9 +36,9 @@ public sealed class CssAuditReport
 
 /// <summary>
 /// Outcome of a <c>--flare-*</c> token synchronization audit (the token counterpart of
-/// <see cref="CssAuditReport"/>). Unlike classes, tokens are NOT expected to be fully in sync today, so
-/// this report is informational (the <c>tokens</c> CLI verb prints it) and is deliberately NOT wired
-/// into a build-failing gate. Each list holds human-readable findings.
+/// <see cref="CssAuditReport"/>). Token usage and <c>Css.Tokens</c> are now fully reconciled, so this is
+/// both printed by the <c>tokens</c> CLI verb and enforced as a build gate by
+/// <c>CssAuditTests.CssTokens_Components_And_Themes_StayInSync</c>. Each list holds human-readable findings.
 /// </summary>
 public sealed class TokenAuditReport
 {


### PR DESCRIPTION
…class gate)

Now that Css.Tokens and the component CSS token usage are fully reconciled ([T+]0/[T-]0/[T~]0), add CssTokens_Components_And_Themes_StayInSync mirroring the existing class-sync gate. It asserts CssAudit.RunTokens().InSync, so a --flare-* token added to Flare.Components CSS without a Css.Tokens constant ([T+]), a constant that loses its last CSS reference ([T-]), or a theme referencing an undeclared token ([T~]) now fails the build. Update the TokenAuditReport doc that still claimed the report was deliberately not a build gate.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
