### PR TITLE
Fix: FlareMaskedField dropped the first char on masks with a leading …

### DIFF
--- a/src/Flare.Components/MaskedField/FlareMaskedField.razor
+++ b/src/Flare.Components/MaskedField/FlareMaskedField.razor
@@ -163,17 +163,22 @@
         var mi = 0;
         foreach (var c in masked)
         {
-            if (mi >= Pattern.Length) break;
-            var mc = Pattern[mi];
-            if (mc == '#' || mc == 'A' || mc == '*')
+            // Walk past literal mask positions first. A literal that is already
+            // present in the input is consumed in place; otherwise the slot is
+            // skipped so this char can fill the next placeholder. Skipping is
+            // what lets a leading literal (e.g. '+' or '(') be auto-filled when
+            // the user types the first value char into an empty field.
+            var consumedLiteral = false;
+            while (mi < Pattern.Length && Pattern[mi] is not ('#' or 'A' or '*'))
             {
-                result.Append(c);
+                if (c == Pattern[mi]) { mi++; consumedLiteral = true; break; }
                 mi++;
             }
-            else
-            {
-                if (c == mc) mi++;
-            }
+            if (consumedLiteral) continue;
+            if (mi >= Pattern.Length) break;
+            // Placeholder position: capture the typed char.
+            result.Append(c);
+            mi++;
         }
         return result.ToString();
     }

--- a/tests/Flare.Components.Tests/Component/CoverageGapTests.cs
+++ b/tests/Flare.Components.Tests/Component/CoverageGapTests.cs
@@ -975,6 +975,48 @@ public class C_FlareMaskedFieldTests : FlareTestContext
         Assert.NotEmpty(cut.FindAll(".flare-input"));
         Assert.NotEmpty(cut.FindAll("input"));
     }
+
+    [Fact]
+    public void LeadingLiteralMask_FirstDigit_AppearsWithLiteral()
+    {
+        // Regression: a mask that starts with a literal ('+') dropped the first
+        // typed digit, so nothing appeared. Typing "7" must render "+7 (".
+        string? bound = null;
+        var cut = Render<FlareMaskedField>(p => p
+            .Add(x => x.Mask, "+# (###) ###-##-##")
+            .Add(x => x.ValueChanged, (string? v) => bound = v));
+
+        cut.Find("input").Input("7");
+
+        Assert.Equal("+7 (", cut.Find("input").GetAttribute("value"));
+        Assert.Equal("+7 (", bound);
+    }
+
+    [Fact]
+    public void LeadingLiteralMask_TypedGroups_ExtractAndReapply()
+    {
+        // The masked string round-trips: re-feeding it keeps only the digits and
+        // re-applies the literals in place.
+        var cut = Render<FlareMaskedField>(p => p
+            .Add(x => x.Mask, "+# (###) ###-##-##"));
+
+        cut.Find("input").Input("+7 (912");
+
+        Assert.Equal("+7 (912) ", cut.Find("input").GetAttribute("value"));
+    }
+
+    [Fact]
+    public void ParenLeadingMask_FirstDigit_AppearsWithLiteral()
+    {
+        // The same class of bug affected any leading literal, e.g. the classic
+        // "(###) ###-####" phone shape.
+        var cut = Render<FlareMaskedField>(p => p
+            .Add(x => x.Mask, "(###) ###-####"));
+
+        cut.Find("input").Input("5");
+
+        Assert.Equal("(5", cut.Find("input").GetAttribute("value"));
+    }
 }
 
 public class C_FlareCodeBlockTests : FlareTestContext


### PR DESCRIPTION
…literal

A mask that starts with a literal (e.g. the Gallery phone mask "+# (###) ###-##-##" or the classic "(###) ###-####") swallowed the first typed digit, so nothing appeared. ExtractRaw matched the first typed char against the leading literal position; on a mismatch it dropped the char WITHOUT advancing the mask pointer, so the digit was lost and ApplyMask returned empty via its raw.Length==0 guard.

ExtractRaw now walks past literal mask positions: a literal present in the input is consumed in place, otherwise the slot is skipped so the char fills the next placeholder. Typing "7" now renders "+7 (".

Tests: 3 regression cases (leading '+' first digit, group round-trip, leading '(' first digit) across net8/9/10.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
