### PR TITLE
Fix: FlareRichTextEditor toolbar threw "dotNetRef is not defined"

### DIFF
--- a/src/Flare.Components.RichTextEditor/wwwroot/js/richtext.js
+++ b/src/Flare.Components.RichTextEditor/wwwroot/js/richtext.js
@@ -26,7 +26,7 @@ export function execCommand(editorId, command, value = null) {
         case 'formatBlock': if (value) wrapAsBlock(range, value); break;
         default: break;
     }
-    dotNetRef.invokeMethodAsync('OnContentChanged', entry.el.innerHTML);
+    entry.dotNetRef.invokeMethodAsync('OnContentChanged', entry.el.innerHTML);
 }
 
 export function getContent(editorId) {


### PR DESCRIPTION
execCommand() referenced a bare `dotNetRef` that is not in its scope -- the ref is stored per-editor as `entry.dotNetRef` (set in init()). Every toolbar button click fell through the switch to that line and threw ReferenceError: dotNetRef is not defined, so no command applied.

Use `entry.dotNetRef.invokeMethodAsync(...)` like the input handler does. Verified in the Gallery: bold + numbered-list now apply and OnContentChanged round-trips the HTML with no console error.

<!-- Thanks for contributing to Flare! Please fill in the sections below. -->

## What does this PR do?

<!-- A short description of the change and the motivation. Link any related issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [ ] `dotnet build Flare.slnx -c Release` succeeds
- [ ] `dotnet test Flare.slnx -c Release` passes (added/updated tests where relevant)
- [ ] Public API has meaningful XML documentation
- [ ] Follows the component conventions (`docs/en/component-conventions.md`)
- [ ] Gallery demo added/updated if a component changed
- [ ] User-facing Gallery strings localized (EN + RU)
- [ ] ASCII-only in code, comments and XML docs

## Screenshots / notes

<!-- For UI changes, before/after screenshots are very welcome. -->
